### PR TITLE
list: Sort the boards displayed.

### DIFF
--- a/src/mpbuild/list_boards.py
+++ b/src/mpbuild/list_boards.py
@@ -10,7 +10,7 @@ def list_boards(port: str = None, links: bool = False) -> None:
     for p in db.keys():
         if not port or (port and port.name == p):
             treep = tree.add(f"{p}   [bright_black]{len(db[p])}[/]")
-            for b in db[p]:
+            for b in sorted(db[p]):
                 variants = ", ".join(db[p][b][0])
                 variants = f" [bright_black]{variants}[/]" if variants else ""
                 treep.add(


### PR DESCRIPTION
Before:
```
anl@STEP: ~/micropython $ mpbuild list --port stm32
🐍 MicroPython Boards
└── stm32   66
    ├── NUCLEO_F722ZE
    ├── NUCLEO_H743ZI2
    ├── MIKROE_CLICKER2_STM32
    ├── ARDUINO_NICLA_VISION
    ├── NUCLEO_H723ZG
    ├── LEGO_HUB_NO7
    ├── STM32F769DISC
    ├── STM32F439
    ├── ARDUINO_GIGA
    ├── ESPRUINO_PICO
    ├── ARDUINO_PORTENTA_H7
    ├── NUCLEO_F401RE
    ├── NUCLEO_F413ZH
    ├── PYBD_SF3
    ├── NUCLEO_L432KC
    ├── VCC_GND_F407ZG
    ├── NUCLEO_F412ZG
    ├── OLIMEX_E407
    ├── WEACT_F411_BLACKPILL  V2_FLASH_4MB, V3_FLASH_8MB
    ├── NETDUINO_PLUS_2
    ├── PYBD_SF2
    ├── GARATRONIC_PYBSTICK26_F411
    ├── STM32F411DISC
    ├── NUCLEO_G474RE
    ├── CERB40
    ├── NUCLEO_H563ZI
    ├── NUCLEO_L073RZ
    ├── NUCLEO_F756ZG
    ├── PYBLITEV10  DP, DP_THREAD, NETWORK, THREAD
    ├── MIKROE_QUAIL
    ├── STM32L496GDISC
    ├── NUCLEO_F411RE
    ├── NUCLEO_L152RE
    ├── NUCLEO_F746ZG
    ├── NUCLEO_F439ZI
    ├── PYBV10  DP, DP_THREAD, NETWORK, THREAD
    ├── ADAFRUIT_F405_EXPRESS
    ├── USBDONGLE_WB55
    ├── VCC_GND_H743VI
    ├── NUCLEO_G0B1RE
    ├── VCC_GND_F407VE
    ├── STM32F429DISC
    ├── NUCLEO_F767ZI
    ├── NUCLEO_F091RC
    ├── STM32H7B3I_DK
    ├── STM32L476DISC
    ├── LIMIFROG
    ├── NUCLEO_L476RG
    ├── NUCLEO_F446RE
    ├── GARATRONIC_NADHAT_F405
    ├── B_L072Z_LRWAN1
    ├── PYBD_SF6
    ├── STM32F7DISC
    ├── STM32F4DISC
    ├── NUCLEO_WL55
    ├── OLIMEX_H407
    ├── NUCLEO_F429ZI
    ├── PYBV11  DP, DP_THREAD, NETWORK, THREAD
    ├── LEGO_HUB_NO6
    ├── NUCLEO_WB55
    ├── SPARKFUN_MICROMOD_STM32
    ├── HYDRABUS
    ├── NUCLEO_H743ZI
    ├── NUCLEO_L4A6ZG
    ├── NUCLEO_L452RE
    └── B_L475E_IOT01A
```

After:
```
anl@STEP: ~/micropython $ mpbuild list --port stm32
🐍 MicroPython Boards
└── stm32   66
    ├── ADAFRUIT_F405_EXPRESS
    ├── ARDUINO_GIGA
    ├── ARDUINO_NICLA_VISION
    ├── ARDUINO_PORTENTA_H7
    ├── B_L072Z_LRWAN1
    ├── B_L475E_IOT01A
    ├── CERB40
    ├── ESPRUINO_PICO
    ├── GARATRONIC_NADHAT_F405
    ├── GARATRONIC_PYBSTICK26_F411
    ├── HYDRABUS
    ├── LEGO_HUB_NO6
    ├── LEGO_HUB_NO7
    ├── LIMIFROG
    ├── MIKROE_CLICKER2_STM32
    ├── MIKROE_QUAIL
    ├── NETDUINO_PLUS_2
    ├── NUCLEO_F091RC
    ├── NUCLEO_F401RE
    ├── NUCLEO_F411RE
    ├── NUCLEO_F412ZG
    ├── NUCLEO_F413ZH
    ├── NUCLEO_F429ZI
    ├── NUCLEO_F439ZI
    ├── NUCLEO_F446RE
    ├── NUCLEO_F722ZE
    ├── NUCLEO_F746ZG
    ├── NUCLEO_F756ZG
    ├── NUCLEO_F767ZI
    ├── NUCLEO_G0B1RE
    ├── NUCLEO_G474RE
    ├── NUCLEO_H563ZI
    ├── NUCLEO_H723ZG
    ├── NUCLEO_H743ZI
    ├── NUCLEO_H743ZI2
    ├── NUCLEO_L073RZ
    ├── NUCLEO_L152RE
    ├── NUCLEO_L432KC
    ├── NUCLEO_L452RE
    ├── NUCLEO_L476RG
    ├── NUCLEO_L4A6ZG
    ├── NUCLEO_WB55
    ├── NUCLEO_WL55
    ├── OLIMEX_E407
    ├── OLIMEX_H407
    ├── PYBD_SF2
    ├── PYBD_SF3
    ├── PYBD_SF6
    ├── PYBLITEV10  DP, DP_THREAD, NETWORK, THREAD
    ├── PYBV10  DP, DP_THREAD, NETWORK, THREAD
    ├── PYBV11  DP, DP_THREAD, NETWORK, THREAD
    ├── SPARKFUN_MICROMOD_STM32
    ├── STM32F411DISC
    ├── STM32F429DISC
    ├── STM32F439
    ├── STM32F4DISC
    ├── STM32F769DISC
    ├── STM32F7DISC
    ├── STM32H7B3I_DK
    ├── STM32L476DISC
    ├── STM32L496GDISC
    ├── USBDONGLE_WB55
    ├── VCC_GND_F407VE
    ├── VCC_GND_F407ZG
    ├── VCC_GND_H743VI
    └── WEACT_F411_BLACKPILL  V2_FLASH_4MB, V3_FLASH_8MB
```