### PR TITLE
Change list port to an argument. Add format option to allow text output.

### DIFF
--- a/src/mpbuild/__init__.py
+++ b/src/mpbuild/__init__.py
@@ -19,3 +19,8 @@ ports.extend(["unix", "webassembly"])
 valid_ports = Enum("Ports", dict(([(p, p) for p in ports])))
 
 board_database = board_db()
+
+
+class OutputFormat(str, Enum):
+    rich = "rich"
+    text = "text"

--- a/src/mpbuild/cli.py
+++ b/src/mpbuild/cli.py
@@ -3,7 +3,7 @@ from typing_extensions import Annotated
 
 import typer
 
-from . import __app_name__, __version__, valid_ports
+from . import __app_name__, __version__, OutputFormat
 from .find_boards import get_port
 from .build import build_board, clean_board, IDF_DEFAULT
 from .list_boards import list_boards
@@ -59,13 +59,18 @@ def clean(
 
 @app.command("list")
 def list_boards_and_variants(
-    port: Annotated[valid_ports, typer.Option(help="port name")] = None,
-    links: Annotated[bool, typer.Option(help="Provide links for boards")] = None,
+    port: Annotated[Optional[str], typer.Argument(help="port name")] = None,
+    fmt: Annotated[
+        OutputFormat,
+        typer.Option(
+            "--format", case_sensitive=False, help="Configure the output format"
+        ),
+    ] = OutputFormat.rich,
 ) -> None:
     """
     List available boards.
     """
-    list_boards(port, links)
+    list_boards(port, fmt)
 
 
 @app.command("check_images")

--- a/src/mpbuild/list_boards.py
+++ b/src/mpbuild/list_boards.py
@@ -2,18 +2,27 @@ from . import board_database
 from rich.tree import Tree
 from rich import print
 
+from .cli import OutputFormat
 
-def list_boards(port: str = None, links: bool = False) -> None:
+
+def list_boards(port: str = None, fmt: OutputFormat = OutputFormat.rich) -> None:
     db = board_database
-    tree = Tree(":snake: [bright_white]MicroPython Boards[/]")
-    tree.add
-    for p in db.keys():
-        if not port or (port and port.name == p):
-            treep = tree.add(f"{p}   [bright_black]{len(db[p])}[/]")
-            for b in sorted(db[p]):
-                variants = ", ".join(db[p][b][0])
-                variants = f" [bright_black]{variants}[/]" if variants else ""
-                treep.add(
-                    f"[bright_white][link={db[p][b][1]['url']}]{b}[/link][/] {variants}"
-                )
-    print(tree)
+
+    if fmt == OutputFormat.rich:
+        tree = Tree(":snake: [bright_white]MicroPython Boards[/]")
+        tree.add
+        for p in db.keys():
+            if not port or (port and port == p):
+                treep = tree.add(f"{p}   [bright_black]{len(db[p])}[/]")
+                for b in sorted(db[p]):
+                    variants = ", ".join(db[p][b][0])
+                    variants = f" [bright_black]{variants}[/]" if variants else ""
+                    treep.add(
+                        f"[bright_white][link={db[p][b][1]['url']}]{b}[/link][/] {variants}"
+                    )
+        print(tree)
+
+    if fmt == OutputFormat.text:
+        """ Output a space-separated list of boards (useful for bash
+        completions). Don't display variants."""
+        print(" ".join([" ".join(sorted(db[p])) for p in db.keys()]))

--- a/src/mpbuild/list_boards.py
+++ b/src/mpbuild/list_boards.py
@@ -25,4 +25,12 @@ def list_boards(port: str = None, fmt: OutputFormat = OutputFormat.rich) -> None
     if fmt == OutputFormat.text:
         """ Output a space-separated list of boards (useful for bash
         completions). Don't display variants."""
-        print(" ".join([" ".join(sorted(db[p])) for p in db.keys()]))
+        print(
+            " ".join(
+                [
+                    " ".join(sorted(db[p]))
+                    for p in db.keys()
+                    if not port or (port and port == p)
+                ]
+            )
+        )


### PR DESCRIPTION
Resolves #10.

The text-only board output seems useful in it's own right but I think will be of particular benefit for #8.