### PR TITLE
Broaden python interface to ease automation

### DIFF
--- a/src/mpbuild/cli.py
+++ b/src/mpbuild/cli.py
@@ -4,7 +4,7 @@ from typing_extensions import Annotated
 import typer
 
 from . import __app_name__, __version__, OutputFormat
-from .find_boards import get_port
+from . import find_boards 
 from .build import build_board, clean_board, IDF_DEFAULT
 from .list_boards import list_boards
 from .check_images import check_images
@@ -12,6 +12,15 @@ from .check_images import check_images
 
 app = typer.Typer()
 
+def get_port(board):
+    try:
+        port = find_boards.get_port(board)
+    except ValueError as e:
+        print(f'"{board}" is an invalid board. Use: mpbuild list')
+        raise typer.Exit(code=1) from e
+
+    print(f'"{board}" is in {port}')
+    return port
 
 @app.command()
 def build(

--- a/src/mpbuild/find_boards.py
+++ b/src/mpbuild/find_boards.py
@@ -2,7 +2,6 @@ from glob import iglob, glob
 from pathlib import Path
 from functools import cache
 import json
-import typer
 
 
 def iports():
@@ -50,8 +49,29 @@ def get_port(board):
     p_and_b = ports_and_boards()
     for p in p_and_b.keys():
         if board in p_and_b[p]:
-            print(f'"{board}" is in {p}')
             return p
 
-    print(f'"{board}" is an invalid board')
-    raise typer.Exit(code=1)
+    raise ValueError(f"'{board}' does not exist.")
+
+def ivariants(board):
+    """
+    Returns as list of tuple(port,variant)
+
+    This is useful for building all variants for a board:
+
+    for port, variant in find_boards.ivariants(board):
+        firmware_filename = build.build_board(port, board, variant)
+    """
+    def get_board_variants(board):
+        port = get_port(board)
+        board= board_db()[port][board]
+        (variants, _details) = board 
+        return port, variants
+
+    port, variants = get_board_variants(board)
+
+    yield port, None
+    if len(variants) > 0:
+        for variant in variants:
+            yield port, variant
+


### PR DESCRIPTION
I gave a try to use mpbuild from octoprobe and I am very happy with the functionality of mpbuild!

In this PR are the changes I did:

* Return the filename of the firmware after a build. Somehow hacky FIRMWARE_FILENAMES-dictionary.
* Removed `import typer`  from `find_boards.py`: Rationale: I do not want generic methods to call type Exceptons.

This PR is just the current state of my work - feel free to reject it:-)