### PR TITLE
Detect / specify micropython directory and auto filter list command if run from port folder.

### DIFF
--- a/src/mpbuild/__init__.py
+++ b/src/mpbuild/__init__.py
@@ -4,13 +4,20 @@ __version__ = "0.1.0"
 from enum import Enum
 from .find_boards import ports_and_boards, board_db
 
-# For testing only!
-import os
 
-try:
-    os.stat("./ports")
-except OSError:
-    raise SystemExit("Please run from root of micropython source tree")
+def find_micropython_root():
+    root = Path(os.environ.get("MICROPY_DIR", ".")).resolve()
+    while True:
+        if (root / "ports").exists() and (root / "mpy-cross").exists():
+            return root, port
+        
+        if root.parent == root:
+            raise SystemExit("Please run from micropython source tree or specify with env: MICROPY_DIR")
+        root = root.parent
+        
+
+root, port = find_micropython_root()
+os.chdir(root)
 
 
 ports = list(ports_and_boards().keys())

--- a/src/mpbuild/__init__.py
+++ b/src/mpbuild/__init__.py
@@ -3,16 +3,12 @@ __version__ = "0.1.0"
 
 from enum import Enum
 from functools import cache
-from .find_boards import ports_and_boards, board_db, find_mpy_root
+from .find_boards import board_db, find_mpy_root
 
 
 @cache
 def board_database(mpy_dir: str = None):
     mpy_dir, port = find_mpy_root(mpy_dir)
-
-    ports = list(ports_and_boards(mpy_dir).keys())
-    # Add 'special' ports - they don't have boards but do have variants
-    ports.extend(["unix", "webassembly"])
 
     db = board_db(mpy_dir, port)
     return db

--- a/src/mpbuild/__init__.py
+++ b/src/mpbuild/__init__.py
@@ -1,38 +1,21 @@
 __app_name__ = "mpbuild"
 __version__ = "0.1.0"
 
-import os
 from enum import Enum
-from pathlib import Path
-from .find_boards import ports_and_boards, board_db
+from functools import cache
+from .find_boards import ports_and_boards, board_db, find_mpy_root
 
 
-def find_micropython_root():
-    port = None
-    root = Path(os.environ.get("MICROPY_DIR", ".")).resolve()
-    while True:
-        # If run from a port folder, store that for use in filters
-        if root.parent.name == "ports":
-            port = root.name
+@cache
+def board_database(mpy_dir: str = None):
+    mpy_dir, port = find_mpy_root(mpy_dir)
 
-        if (root / "ports").exists() and (root / "mpy-cross").exists():
-            return root, port
-        
-        if root.parent == root:
-            raise SystemExit("Please run from micropython source tree or specify with env: MICROPY_DIR")
-        root = root.parent
-        
+    ports = list(ports_and_boards(mpy_dir).keys())
+    # Add 'special' ports - they don't have boards but do have variants
+    ports.extend(["unix", "webassembly"])
 
-root, port = find_micropython_root()
-os.chdir(root)
-
-
-ports = list(ports_and_boards().keys())
-# Add 'special' ports - they don't have boards but do have variants
-ports.extend(["unix", "webassembly"])
-valid_ports = Enum("Ports", dict(([(p, p) for p in ports])))
-
-board_database = board_db(port)
+    db = board_db(mpy_dir, port)
+    return db
 
 
 class OutputFormat(str, Enum):

--- a/src/mpbuild/__init__.py
+++ b/src/mpbuild/__init__.py
@@ -1,13 +1,20 @@
 __app_name__ = "mpbuild"
 __version__ = "0.1.0"
 
+import os
 from enum import Enum
+from pathlib import Path
 from .find_boards import ports_and_boards, board_db
 
 
 def find_micropython_root():
+    port = None
     root = Path(os.environ.get("MICROPY_DIR", ".")).resolve()
     while True:
+        # If run from a port folder, store that for use in filters
+        if root.parent.name == "ports":
+            port = root.name
+
         if (root / "ports").exists() and (root / "mpy-cross").exists():
             return root, port
         
@@ -25,7 +32,7 @@ ports = list(ports_and_boards().keys())
 ports.extend(["unix", "webassembly"])
 valid_ports = Enum("Ports", dict(([(p, p) for p in ports])))
 
-board_database = board_db()
+board_database = board_db(port)
 
 
 class OutputFormat(str, Enum):

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -75,12 +75,12 @@ def build_board(
     # fmt: off
     build_cmd = (
         f"docker run -it --rm "
-        f"-v /sys/bus:/sys/bus "              # provides access to USB for deploy
-        f"-v /dev:/dev "                      # provides access to USB for deploy
-        f"--net=host --privileged "           # provides access to USB for deploy
-        f"-v {mpy_dir}:{mpy_dir} -w {mpy_dir} "           # mount micropython dir with same path so elf/map paths match host
-        f"--user {uid}:{gid} "                # match running user id so generated files aren't owned by root
-        f"-v {home}:{home} -e HOME={home} "   # when changing user id to one not present in container this ensures home is writable
+        f"-v /sys/bus:/sys/bus "                # provides access to USB for deploy
+        f"-v /dev:/dev "                        # provides access to USB for deploy
+        f"--net=host --privileged "             # provides access to USB for deploy
+        f"-v {mpy_dir}:{mpy_dir} -w {mpy_dir} " # mount micropython dir with same path so elf/map paths match host
+        f"--user {uid}:{gid} "                  # match running user id so generated files aren't owned by root
+        f"-v {home}:{home} -e HOME={home} "     # when changing user id to one not present in container this ensures home is writable
         f"{build_container} "
         f'bash -c "'
         f"git config --global --add safe.directory '*' 2> /dev/null;"

--- a/src/mpbuild/check_images.py
+++ b/src/mpbuild/check_images.py
@@ -9,8 +9,8 @@ from rich.panel import Panel
 from rich.table import Table
 
 
-def check_images(verbose: bool = False) -> None:
-    db = board_database
+def check_images(verbose: bool = False, mpy_dir: str = None) -> None:
+    db = board_database(mpy_dir)
     # TODO(mst) A minor improvement: Should count the number of images in all
     # the boards for each port (this assumes one per board).
     num_boards = sum([len(db[p]) for p in db.keys()])

--- a/src/mpbuild/find_boards.py
+++ b/src/mpbuild/find_boards.py
@@ -8,6 +8,7 @@ import typer
 
 SPECIAL_PORTS = ["unix", "webassembly", "windows"]
 
+
 def port_and_board(mpy_dir):
     for p in iglob(f"{mpy_dir}/ports/**/boards/**/"):
         path = Path(p)
@@ -33,7 +34,7 @@ def find_mpy_root(root: str = None):
 
         if root.parent == root:
             raise SystemExit(
-                "Please run from micropython source tree or specify with env: MICROPY_DIR"
+                "Please run from MicroPython source tree or specify with env: MICROPY_DIR"
             )
         root = root.parent
 

--- a/src/mpbuild/find_boards.py
+++ b/src/mpbuild/find_boards.py
@@ -28,11 +28,13 @@ def port_and_board():
 
 
 @cache
-def board_db():
+def board_db(single_port):
     db = dict()
     for p in glob("ports/**/boards/**/board.json"):
         path = Path(p)
         port, board = path.parent.parent.parent.name, path.parent.name
+        if single_port and port != single_port:
+            continue
         with open(p) as f:
             details = json.load(f)
             variants = (

--- a/src/mpbuild/list_boards.py
+++ b/src/mpbuild/list_boards.py
@@ -5,8 +5,10 @@ from rich import print
 from .cli import OutputFormat
 
 
-def list_boards(port: str = None, fmt: OutputFormat = OutputFormat.rich) -> None:
-    db = board_database
+def list_boards(
+    port: str = None, fmt: OutputFormat = OutputFormat.rich, mpy_dir: str = None
+) -> None:
+    db = board_database(mpy_dir)
 
     if fmt == OutputFormat.rich:
         tree = Tree(":snake: [bright_white]MicroPython Boards[/]")


### PR DESCRIPTION
Allows running from anywhere in micropython tree.

Alternatively specify micropython root directory with environment variable: `MICROPY_DIR`

When run from a port folder, eg `micropython/ports/stm32` auto-filter `list` command to that current port.

