### PR TITLE
Add support for boardless ports

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -46,7 +46,8 @@ def build_board(
             idf = IDF_DEFAULT
         build_container += f":{idf}"
 
-    variant = f" BOARD_VARIANT={variant}" if variant else ""
+    variant_param = "VARIANT" if board == port else "BOARD_VARIANT"
+    variant = f" {variant_param}={variant}" if variant else ""
 
     args = " " + " ".join(extra_args)
 

--- a/src/mpbuild/find_boards.py
+++ b/src/mpbuild/find_boards.py
@@ -5,6 +5,9 @@ import json
 import typer
 
 
+SPECIAL_PORTS = ["unix", "webassembly", "windows"]
+
+
 def iports():
     for p in iglob("ports/**/"):
         yield Path(p).name
@@ -19,6 +22,9 @@ def port_and_board():
     for p in iglob("ports/**/boards/**/"):
         path = Path(p)
         yield path.parent.parent.name, path.name
+
+    for port in SPECIAL_PORTS:
+        yield port, port
 
 
 @cache
@@ -35,6 +41,19 @@ def board_db():
             db.setdefault(port, {})
             db[port].setdefault(board, {})
             db[port][board] = (variants, details)
+
+    # "Special" ports - don't have boards
+    for port in SPECIAL_PORTS:
+        path = Path("ports", port)
+        board = port
+        details = {
+            "url": f"https://github.com/micropython/micropython/blob/master/ports/{port}/README.md"
+        }
+        variants = [var.name for var in path.glob("variants/*") if var.is_dir()]
+        db.setdefault(port, {})
+        db[port].setdefault(board, {})
+        db[port][board] = (variants, details)
+
     return db
 
 


### PR DESCRIPTION
Adds support for listing and attempting to build the three boardless "special" ports, `unix`, `webassembly`, and `windows`. This includes both listing and building variants.

Only the `unix` port actually builds as it is the only one with a build container provided in build.py, however the others successfully attempt the build and gracefully fail as expected with "Sorry, builds are not supported for the <PORT> port at this time".

For the boardless ports, internally the board is set to the same value as the port. As this is not the case for any of the boardful (?) ports, this can be used to determine when you're handling a special port and treat it accordingly, while also providing an acceptable (albeit redundant and verbose) user experience during board listing. It may be a preferential user experience to have these all listed under the parent of "special" or similar however this may misconstrue the ports as being somehow related, which isn't the case.