### PR TITLE
Refactor board_database and find_mpy_root functions to accept Path objects

### DIFF
--- a/src/mpbuild/__init__.py
+++ b/src/mpbuild/__init__.py
@@ -3,15 +3,16 @@ __version__ = "0.1.0"
 
 from enum import Enum
 from functools import cache
+from pathlib import Path
 from .find_boards import find_mpy_root
 from .board_database import Database
 
 
 @cache
-def board_database(mpy_dir: str = None, port: str = None) -> Database:
+def board_database(mpy_dir: Path | None = None, port: str | None = None) -> Database:
     mpy_dir, auto_port = find_mpy_root(mpy_dir)
     port = port or auto_port
-
+    # assert port
     return Database(mpy_dir, port)
 
 

--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -91,7 +91,7 @@ class Board:
     Files that explain how to deploy for this board:
     Example: ["../PYBV10/deploy.md"]
     """
-    port: Port = field(default=None, compare=False)
+    port: Port | None= field(default=None, compare=False)
 
     @staticmethod
     def factory(filename_json: Path) -> Board:
@@ -132,8 +132,8 @@ class Database:
     This database contains all information retrieved from all 'board.json' files.
     """
 
-    mpy_root_directory: str = field(repr=False)
-    port_filter: bool = field(default=False, repr=False)
+    mpy_root_directory: Path = field(repr=False)
+    port_filter: str = field(default="", repr=False)
 
     ports: dict[str, Port] = field(default_factory=dict)
     boards: dict[str, Board] = field(default_factory=dict)

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -31,11 +31,13 @@ nprocs = multiprocessing.cpu_count()
 def build_board(
     board: str,
     variant: Optional[str] = None,
-    extra_args: Optional[List[str]] = [],
+    extra_args: List[str] = [],
     build_container_override: Optional[str] = None,
     idf: Optional[str] = IDF_DEFAULT,
-    mpy_dir: str = None,
+    mpy_dir: str|Path|None = None,
 ) -> None:
+    # mpy_dir = mpy_dir or Path.cwd()
+    # mpy_dir = Path(mpy_dir)
     db = board_database(mpy_dir)
 
     if board not in db.boards.keys():
@@ -123,7 +125,7 @@ def build_board(
         deploy_filename = Path(
             "/".join(
                 [
-                    mpy_dir,
+                    str(mpy_dir),
                     "ports",
                     _board.port.name,
                     "boards",
@@ -141,7 +143,7 @@ def clean_board(
     board: str,
     variant: Optional[str] = None,
     idf: Optional[str] = IDF_DEFAULT,
-    mpy_dir: str = None,
+    mpy_dir: Optional[str] = None,
 ) -> None:
     build_board(
         board=board,

--- a/src/mpbuild/find_boards.py
+++ b/src/mpbuild/find_boards.py
@@ -4,10 +4,11 @@ from functools import cache
 
 
 @cache
-def find_mpy_root(root: str = None):
+def find_mpy_root(root: str| Path | None = None):
     if root is None:
         root = Path(os.environ.get("MICROPY_DIR", ".")).resolve()
-
+    else:
+        root = Path(root)
     port = None
     while True:
         # If run from a port folder, store that for use in filters
@@ -15,7 +16,7 @@ def find_mpy_root(root: str = None):
             port = root.name
 
         if (root / "ports").exists() and (root / "mpy-cross").exists():
-            return str(root), port
+            return root, port
 
         if root.parent == root:
             raise SystemExit(

--- a/src/mpbuild/list_boards.py
+++ b/src/mpbuild/list_boards.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from . import board_database
 from rich.tree import Tree
 from rich import print
@@ -6,7 +7,9 @@ from .cli import OutputFormat
 
 
 def list_boards(
-    port: str = None, fmt: OutputFormat = OutputFormat.rich, mpy_dir: str = None
+    port: Optional[str] = None, 
+    fmt: OutputFormat = OutputFormat.rich, 
+    mpy_dir: Optional[str] = None,
 ) -> None:
     db = board_database(mpy_dir, port)
 


### PR DESCRIPTION
While chasing down the missing mpy_path assignment I was utterly confused by the mismatch between the actual types and the type annotations.

this is my take on it which are mostly updates to the annotations,
but also includes some casts and changes of defaults to better match the type.

This commit refactors the board_database and find_mpy_root functions to accept Path objects instead of strings for the mpy_dir parameter. This change improves the code's readability and makes it more consistent with the use of Path objects throughout the project.