### PR TITLE
Reduce the output when displaying parts of the Board Database in the REPL

### DIFF
--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -50,7 +50,7 @@ class Variant:
     """
     Example: "Double precision float + Threads"
     """
-    board: Board
+    board: Board = field(repr=False)
 
 
 @dataclass(order=True)
@@ -120,7 +120,7 @@ class Port:
     """
     Example: "stm32"
     """
-    boards: dict[str, Board] = field(default_factory=dict)
+    boards: dict[str, Board] = field(default_factory=dict, repr=False)
     """
     Example key: "PYBV11"
     """


### PR DESCRIPTION
Viewing parts of the Board Database is very 'noisy'. This change means that Variants won't display the Boards they belong to. The bigger change is that Ports don't show their Boards. 

This may seem counter-intuitive except that the more common way to 'view' the DB is via Boards. Since boards also link back to their ports there is a circular output that is too verbose to be useful.