### PR TITLE
Update build.py to support running on Windows using Docker via WSL2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,36 @@
 
 - Should it list boards and variants? (yes, probably. Alternatively, '-a'.)
 
+
+## requirements to use on Linux
+
+- Docker or compatible container runtime
+- Python 3.x
+
+## Requirements to use on Windows
+
+- Docker or compatible container runtime using WSL2
+- Python 3.x
+- WSL2
+- Linux Distro: Ubuntu, Arch, Kali-linux have been tested
+
+- micropython repo cloned to a WSL2 hosted directory
+  `/home/<user>/micropython`
+
+- MICROPY_DIR set to the WSL2 hosted directory
+  `$env:MICROPY_DIR="\\wsl.localhost\Ubuntu\home\<user>\micropython"`
+
+- Optional: Windows drive letter mapped to WSL2 hosted directory
+  `net use U: \\wsl$\Ubuntu`
+  `dir U:\home\<user>\micropython\ports\rp2\build_RPI_PICO\firmware.uf2`
+
 ## Development
 
 - rye for managing the project
+    ``` shell
+    rye sync
+    rye build
+    ```
 - Use ruff for formatting
 - pre-commit
   - ruff formatting and linting


### PR DESCRIPTION
Hi,

I added logic to allow mpbuild to work on Windows + WSL2 
for a speedy build the micropython repo needs to be hosted on the WSL2 filesystem, but it also works (given sufficient patience) on just a windows drive.

The changes are mostly path manipulation to translate from Windows to Linux paths, and to select a correct HOME folder.

![arch-pico](https://github.com/user-attachments/assets/28c0dd77-287a-4f7b-959e-2ff8719998ac)


There are a few things that may need additional attention, but I have not bisected them against pure linux  : 

- [ ] `mpbuild build BOARD clean` does not work correctly,
      `mpbuild build BOARD VARIANT clean` does work , and  `mpbuild clean BOARD`  also 
    ```
     (mpbuild) PS D:\> mpbuild build PIMORONI_TINY2040  clean
    Invalid variant
    ```
- [ ] Tab completion, registration seems to work, but nothing is completed 
- [ ] running against the Debian Distro does not work, seems to be a permission issue of some kind. 
