### PR TITLE
Handle '~' in find_mpy_root function

### DIFF
--- a/src/mpbuild/find_boards.py
+++ b/src/mpbuild/find_boards.py
@@ -6,9 +6,9 @@ from pathlib import Path
 @cache
 def find_mpy_root(root: str | Path | None = None) -> tuple[Path, str]:
     if root is None:
-        root = Path(os.environ.get("MICROPY_DIR", ".")).resolve()
+        root = Path(os.environ.get("MICROPY_DIR", ".")).expanduser().resolve()
     else:
-        root = Path(root)
+        root = Path(root).expanduser().resolve()
 
     port = ""
     while True:

--- a/tests/test_find_boards.py
+++ b/tests/test_find_boards.py
@@ -22,6 +22,19 @@ class TestFindMpyRoot:
         assert result == mpy_root
         assert port == ""
 
+    def test_resolves_tilde_in_explicit_root_path(self, tmp_path, monkeypatch):
+        """An explicit root using '~' is expanded and resolved before lookup."""
+        home = tmp_path / "home"
+        root = home / "micropython"
+        (root / "ports").mkdir(parents=True)
+        (root / "mpy-cross").mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        result, port = find_mpy_root("~/micropython")
+
+        assert result == root.resolve()
+        assert port == ""
+
     def test_walks_up_to_find_root(self, mpy_root):
         """Walks parent dirs until ports/ + mpy-cross/ are found."""
         deep = mpy_root / "ports" / "stm32" / "boards" / "PYBV11"


### PR DESCRIPTION
Add support for folder configuration such as `MICROPY_DIR=~/micropython`.

