### PR TITLE
Please close -> supersed by #54: Introduce mpbuild api to be used by octoprobe

### DIFF
--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -59,6 +59,11 @@ class Board:
     """
     Example: "PYBV11"
     """
+    directory: Path
+    """
+    The directory of the source code.
+    Example: ".../ports/esp32"
+    """
     variants: list[Variant]
     """
     List of variants available for this board.
@@ -100,6 +105,7 @@ class Board:
 
         board = Board(
             name=filename_json.parent.name,
+            directory=filename_json.parent,
             variants=[],
             url=board_json["url"],
             mcu=board_json["mcu"],
@@ -112,6 +118,10 @@ class Board:
             sorted([Variant(*v, board) for v in board_json.get("variants", {}).items()])
         )
         return board
+
+    @property
+    def deploy_filename(self) -> Path:
+        return self.directory / self.deploy[0]
 
 
 @dataclass(order=True)
@@ -175,14 +185,15 @@ class Database:
                 var.name for var in path.glob("variants/*") if var.is_dir()
             ]
             board = Board(
-                special_port_name,
-                [],
-                f"https://github.com/micropython/micropython/blob/master/ports/{special_port_name}/README.md",
-                "",
-                "",
-                "",
-                [],
-                [],
+                name=special_port_name,
+                directory=path,
+                variants=[],
+                url=f"https://github.com/micropython/micropython/blob/master/ports/{special_port_name}/README.md",
+                mcu="",
+                product="",
+                vendor="",
+                images=[],
+                deploy=[],
             )
             board.variants = [Variant(v, "", board) for v in variant_names]
             port = Port(special_port_name, {special_port_name: board})

--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -141,7 +141,7 @@ class Database:
     def __post_init__(self) -> None:
         mpy_dir = self.mpy_root_directory
         # Take care to avoid using Path.glob! Performance was 15x slower.
-        for p in glob(f"{mpy_dir}/ports/**/boards/**/board.json"):
+        for p in glob(f"{mpy_dir}/ports/*/boards/*/board.json"):
             filename_json = Path(p)
             port_name = filename_json.parent.parent.parent.name
             if self.port_filter and self.port_filter != port_name:

--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -139,9 +139,14 @@ class Database:
     boards: dict[str, Board] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        mpy_dir = self.mpy_root_directory
+        assert isinstance(self.mpy_root_directory, Path)
+        assert isinstance(self.port_filter, str)
+
+        if not (self.mpy_root_directory / "ports").is_dir():
+            raise ValueError(f"'mpy_root_directory' should point to the top of a micropython repo: {self.mpy_root_directory}")
+
         # Take care to avoid using Path.glob! Performance was 15x slower.
-        for p in glob(f"{mpy_dir}/ports/*/boards/*/board.json"):
+        for p in glob(f"{self.mpy_root_directory}/ports/*/boards/*/board.json"):
             filename_json = Path(p)
             port_name = filename_json.parent.parent.parent.name
             if self.port_filter and self.port_filter != port_name:
@@ -165,7 +170,7 @@ class Database:
         for special_port_name in ["unix", "webassembly", "windows"]:
             if self.port_filter and self.port_filter != special_port_name:
                 continue
-            path = Path(mpy_dir, "ports", special_port_name)
+            path = self.mpy_root_directory / "ports" / special_port_name
             variant_names = [
                 var.name for var in path.glob("variants/*") if var.is_dir()
             ]

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -123,21 +123,8 @@ def build_board(
     #    >>> len(db.boards())
     #    169  # 3x boards are the 'special' boards without deployment instructions.
     if _board.deploy and "clean" not in extra_args:
-        deploy_filename = Path(
-            "/".join(
-                [
-                    str(mpy_dir),
-                    "ports",
-                    _board.port.name,
-                    "boards",
-                    _board.name,
-                    _board.deploy[0],
-                ]
-            )
-        )
-        if deploy_filename.is_file():
-            with open(deploy_filename) as deployfile:
-                print(Panel(Markdown(deployfile.read())))
+        if _board.deploy_filename.is_file():
+            print(Panel(Markdown(_board.deploy_filename.read_text())))
 
 
 def clean_board(

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -35,7 +35,7 @@ def build_board(
     build_container_override: Optional[str] = None,
     idf: Optional[str] = IDF_DEFAULT,
     mpy_dir: str|Path|None = None,
-) -> pathlib.Path:
+) -> None:
     # mpy_dir = mpy_dir or Path.cwd()
     # mpy_dir = Path(mpy_dir)
     mpy_dir, _ = find_mpy_root(mpy_dir)

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -35,7 +35,7 @@ def build_board(
     build_container_override: Optional[str] = None,
     idf: Optional[str] = IDF_DEFAULT,
     mpy_dir: str|Path|None = None,
-) -> None:
+) -> pathlib.Path:
     # mpy_dir = mpy_dir or Path.cwd()
     # mpy_dir = Path(mpy_dir)
     mpy_dir, _ = find_mpy_root(mpy_dir)
@@ -51,7 +51,6 @@ def build_board(
     if variant and variant not in [v.name for v in _board.variants]:
         print("Invalid variant")
         raise SystemExit()
-
     if port not in BUILD_CONTAINERS.keys():
         print(f"Sorry, builds are not supported for the {port} port at this time")
         raise SystemExit()
@@ -113,7 +112,11 @@ def build_board(
     title += f" {port}/{board}" + (f" ({variant})" if variant else "")
     print(Panel(build_cmd, title=title, title_align="left", padding=1))
 
-    subprocess.run(build_cmd, shell=True)
+    proc = subprocess.run(build_cmd, shell=True, check=False)
+
+    if proc.returncode != 0:
+        print(f"ERROR: The following command returned {proc.returncode}: {build_cmd}")
+        raise SystemExit(proc.returncode)
 
     # Display deployment markdown
     # Note: Only displaying the first deploy file.

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -21,6 +21,7 @@ BUILD_CONTAINERS = {
     "renesas-ra": ARM_BUILD_CONTAINER,
     "samd": ARM_BUILD_CONTAINER,
     "esp32": "espressif/idf",
+    "esp8266": "larsks/esp-open-sdk",
     "unix": "gcc:12-bookworm",  # Special, doesn't have boards
 }
 

--- a/src/mpbuild/build_api.py
+++ b/src/mpbuild/build_api.py
@@ -79,7 +79,8 @@ class Firmware:
 _FIRMWARE_FILENAMES = {
     "stm32": "firmware.dfu",
     "rp2": "firmware.uf2",
-    "esp32": "micropython.bin",
+    "esp32": "firmware.bin",
+    "esp8266": "firmware.bin",
     "unix": "micropython",
 }
 

--- a/src/mpbuild/build_api.py
+++ b/src/mpbuild/build_api.py
@@ -1,0 +1,166 @@
+"""
+This is the api interface for mpbuild
+"""
+
+import subprocess
+from pathlib import Path
+from dataclasses import dataclass
+
+from .board_database import Variant
+from .build import MpbuildNotSupportedException, docker_build_cmd
+from .board_database import Database
+
+
+class MpbuildException(Exception):
+    """
+    Thrown by the API if the build fails.
+    """
+
+
+class MpbuildDockerException(MpbuildException):
+    """
+    Thrown by the API if docker fails.
+    The exception contains
+    * the variant which failed
+    * proc.returncode
+    * proc.stdout
+    * proc.stderr
+
+    stdout/stderr might be very long!
+    """
+
+    def __init__(self, variant: Variant, proc: subprocess.CompletedProcess) -> None:
+        super().__init__(f"Failed to build {variant.name_full}")
+        self.proc = proc
+
+    def __str__(self) -> str:
+        """
+        As the docker build failed, also return the docker output - which may be many lines long!
+        """
+        lines = (
+            super().__str__(),
+            f"returncode: {self.proc.returncode}",
+            f"stdout: {self.proc.stdout}",
+            f"stderr: {self.proc.stderr}",
+        )
+        return "\n  ".join(lines)
+
+@dataclass(frozen=True, order=True)
+class Firmware:
+    filename: Path
+    """
+    the compiled firmware
+    """
+
+    variant: Variant
+    """
+    The variant used to build the firmware.
+
+    This is used by octoprobe to find matching MCUs/boards.
+    """
+
+    micropython_version_text: str | None
+    """
+    Example:
+    Calling '>>> micropython_version'
+    on firmware https://micropython.org/resources/firmware/PYBV11-20240602-v1.23.0.dfu
+    will return: '3.4.0; MicroPython v1.23.0 on 2024-06-02'
+
+    This string will be used by octoprobe to verify if the correct firmware is installed.
+
+    Set to 'None' if the value is not known.
+    """
+
+    def __str__(self) -> str:
+        return f"Firmware({self.variant.name_full}, {self.filename}, {self.micropython_version_text})"
+
+
+_FIRMWARE_FILENAMES = {
+    "stm32": "firmware.dfu",
+    "rp2": "firmware.uf2",
+    "esp32": "micropython.bin",
+    "unix": "micropython",
+}
+
+
+def get_firmware_filename(variant: Variant) -> Path:
+    """
+    Returns the filename of the compiled binary.
+    """
+    try:
+        board = variant.board
+        assert board.port is not None
+        port = board.port
+        port_name = port.name
+        board_name = variant.board.name
+        variant_name = variant.name
+
+        filename = _FIRMWARE_FILENAMES[port_name]
+        if board.physical_board:
+            # Example: board_name == 'stm32'
+            build_directory = f"build-{board_name}"
+            if not variant.is_default_variant:
+                build_directory += f"-{variant_name}"
+            return port.directory / build_directory / filename
+
+        # Example: board_name == 'unix'
+        return port.directory / f"build-{variant_name}" / filename
+    except KeyError as e:
+        raise MpbuildNotSupportedException(
+            f"Entry port='{port_name}' missing in 'FIRMWARE_FILENAMES'!"
+        ) from e
+
+
+def build_by_variant(
+    variant: Variant, do_clean: bool
+) -> tuple[Firmware, subprocess.CompletedProcess]:
+    """ """
+    assert isinstance(variant, Variant)
+    assert isinstance(do_clean, bool)
+
+    build_cmd = docker_build_cmd(variant=variant, do_clean=do_clean, extra_args=[])
+
+    proc = subprocess.run(
+        build_cmd,
+        shell=True,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        # print(f"Error calling: {build_cmd}")
+        # print(f"stdout: {proc.stdout}")
+        # print(f"stderr: {proc.stderr}")
+        raise MpbuildDockerException(variant=variant, proc=proc)
+
+    filename = get_firmware_filename(variant)
+    if not filename.is_file():
+        raise MpbuildException(
+            f"The firmware for {variant.name_full} was not found: {filename}"
+        )
+
+    return (
+        Firmware(filename=filename, variant=variant, micropython_version_text=None),
+        proc,
+    )
+
+
+def build_by_variant_str(
+    db: Database, variant_str: str, do_clean: bool
+) -> tuple[Firmware, subprocess.CompletedProcess]:
+    """
+    This will build the firmware and return
+    * firmware: Firmware: The path to the firmware and much more
+    * proc: The output from the docker container. This might be useful for logging purposes.
+
+    If the build fails:
+    * an exception is raised
+    * captured output with the error message is written to stdout/strerr (it would be better to write it to a logfile)
+    """
+    assert isinstance(db, Database)
+    assert isinstance(variant_str, str)
+    assert isinstance(do_clean, bool)
+
+    board_str, _, variant_str = variant_str.partition("-")
+    db_variant = db.get_board(board_str).get_variant(variant_str)
+    return build_by_variant(variant=db_variant, do_clean=do_clean)

--- a/src/mpbuild/build_api.py
+++ b/src/mpbuild/build_api.py
@@ -45,6 +45,7 @@ class MpbuildDockerException(MpbuildException):
         )
         return "\n  ".join(lines)
 
+
 @dataclass(frozen=True, order=True)
 class Firmware:
     filename: Path
@@ -118,7 +119,12 @@ def build_by_variant(
     assert isinstance(variant, Variant)
     assert isinstance(do_clean, bool)
 
-    build_cmd = docker_build_cmd(variant=variant, do_clean=do_clean, extra_args=[])
+    build_cmd = docker_build_cmd(
+        variant=variant,
+        do_clean=do_clean,
+        extra_args=[],
+        docker_interactive=False,
+    )
 
     proc = subprocess.run(
         build_cmd,

--- a/src/mpbuild/completions.py
+++ b/src/mpbuild/completions.py
@@ -13,5 +13,5 @@ def list_boards() -> list[str]:
 
 def list_variants_for_board(board: str) -> list[str]:
     db = board_database()
-    variants = db.boards[board].variants
+    variants = db.boards[board].variants_without_default
     return [v.name for v in variants if v]

--- a/src/mpbuild/find_boards.py
+++ b/src/mpbuild/find_boards.py
@@ -4,13 +4,13 @@ from functools import cache
 
 
 @cache
-def find_mpy_root(root: str| Path | None = None):
+def find_mpy_root(root: str| Path | None = None) -> tuple[Path, str]:
     if root is None:
         root = Path(os.environ.get("MICROPY_DIR", ".")).resolve()
     else:
         root = Path(root)
 
-    port = None
+    port = ""
     while True:
         # If run from a port folder, store that for use in filters
         if root.parent.name == "ports":

--- a/src/mpbuild/list_boards.py
+++ b/src/mpbuild/list_boards.py
@@ -21,7 +21,7 @@ def print_boards(
             if not port or (port and port == p.name):
                 treep = tree.add(f"{p.name}   [bright_black]{len(p.boards)}[/]")
                 for b in sorted(p.boards.values()):
-                    variants = ", ".join([v.name for v in b.variants])
+                    variants = ", ".join([v.name for v in b.variants_without_default])
                     variants = f" [bright_black]{variants}[/]" if variants else ""
                     treep.add(
                         f"[bright_white][link={b.url}]{b.name}[/link][/] {variants}"

--- a/tests/README_tests.md
+++ b/tests/README_tests.md
@@ -16,5 +16,5 @@ export MICROPY_DIR=~/micropython_firmware
 ```bash
 export MICROPY_DIR=~/micropython_firmware
 python tests/test_build_board_for_each_port.py
-python tests/test_test_build_some_variants.py
+python tests/test_build_some_variants.py
 ```

--- a/tests/README_tests.md
+++ b/tests/README_tests.md
@@ -1,0 +1,20 @@
+# Tests for mpbuild
+
+These tests have to be started manually.
+
+The tests succeeded if they do not throw an exception.
+
+## Testing the command line interface `mpbuild build`:
+
+```bash
+export MICROPY_DIR=~/micropython_firmware
+./tests/test_build_some_variants.sh
+```
+
+## Testing the API
+
+```bash
+export MICROPY_DIR=~/micropython_firmware
+python tests/test_build_board_for_each_port.py
+python tests/test_test_build_some_variants.py
+```

--- a/tests/test_build_board_for_each_port.py
+++ b/tests/test_build_board_for_each_port.py
@@ -22,11 +22,11 @@ def main():
             for variant in board.variants[0:NUMBER_VARIANTS]:
                 print(f"Testing {variant.name_full}")
                 try:
-                    filename_firmware = build_by_variant(
+                    firmware = build_by_variant(
                         variant=variant,
                         do_clean=False,
                     )
-                    print(f"  {filename_firmware}")
+                    print(f"  {firmware}")
                 except MpbuildNotSupportedException:
                     print("  Not supported!")
 

--- a/tests/test_build_board_for_each_port.py
+++ b/tests/test_build_board_for_each_port.py
@@ -1,0 +1,35 @@
+"""
+Call mpbuild for all boards.
+Tests the first two variants.
+
+Goal is a high test coverage of the boards.
+"""
+
+from mpbuild.build_api import build_by_variant
+from mpbuild.build import MpbuildNotSupportedException
+
+from test_build_some_variants import get_db
+
+NUMBER_BOARDS = 1
+NUMBER_VARIANTS = 2
+
+
+def main():
+    db = get_db()
+
+    for port in db.ports.values():
+        for board in list(port.boards.values())[0:NUMBER_BOARDS]:
+            for variant in board.variants[0:NUMBER_VARIANTS]:
+                print(f"Testing {variant.name_full}")
+                try:
+                    filename_firmware = build_by_variant(
+                        variant=variant,
+                        do_clean=False,
+                    )
+                    print(f"  {filename_firmware}")
+                except MpbuildNotSupportedException:
+                    print("  Not supported!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build_some_variants.py
+++ b/tests/test_build_some_variants.py
@@ -31,7 +31,7 @@ _VARIANTS_TO_TEST = (
 def get_db() -> Database:
     try:
         mpy_root_directory = Path(os.environ[MICROPY_DIR])
-        return Database(mpy_root_directory=mpy_root_directory, port_filter="")
+        return Database(mpy_root_directory=mpy_root_directory)
     except KeyError as e:
         raise SystemExit(
             f"The environment variable '{MICROPY_DIR}' is not defined!"
@@ -43,12 +43,12 @@ def main():
 
     for variant_str in _VARIANTS_TO_TEST:
         print(f"Testing {variant_str}")
-        filename_firmware = build_by_variant_str(
+        firmware = build_by_variant_str(
             db=db,
             variant_str=variant_str,
             do_clean=False,
         )
-        print(f"  {filename_firmware}")
+        print(f"  {firmware}")
 
 
 if __name__ == "__main__":

--- a/tests/test_build_some_variants.py
+++ b/tests/test_build_some_variants.py
@@ -20,6 +20,7 @@ _VARIANTS_TO_TEST = (
     "RPI_PICO2-RISCV",
     # Standard case
     "PYBV11",
+    "ESP8266_GENERIC",
     # Special case: Variant
     "PYBV11-THREAD",
     # Special case: Unix

--- a/tests/test_build_some_variants.py
+++ b/tests/test_build_some_variants.py
@@ -1,0 +1,55 @@
+"""
+Call mpbuild for some selected boards and variants.
+
+Goal is a high test coverage.
+"""
+
+import os
+from pathlib import Path
+
+from mpbuild.build_api import build_by_variant_str
+from mpbuild.board_database import Database
+
+
+MICROPY_DIR = "MICROPY_DIR"
+
+_VARIANTS_TO_TEST = (
+    # Standard case
+    "RPI_PICO2",
+    # Special case: Variant uses another build container
+    "RPI_PICO2-RISCV",
+    # Standard case
+    "PYBV11",
+    # Special case: Variant
+    "PYBV11-THREAD",
+    # Special case: Unix
+    "unix-minimal",
+    "unix-coverage",
+)
+
+
+def get_db() -> Database:
+    try:
+        mpy_root_directory = Path(os.environ[MICROPY_DIR])
+        return Database(mpy_root_directory=mpy_root_directory, port_filter="")
+    except KeyError as e:
+        raise SystemExit(
+            f"The environment variable '{MICROPY_DIR}' is not defined!"
+        ) from e
+
+
+def main():
+    db = get_db()
+
+    for variant_str in _VARIANTS_TO_TEST:
+        print(f"Testing {variant_str}")
+        filename_firmware = build_by_variant_str(
+            db=db,
+            variant_str=variant_str,
+            do_clean=False,
+        )
+        print(f"  {filename_firmware}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build_some_variants.sh
+++ b/tests/test_build_some_variants.sh
@@ -29,6 +29,7 @@ mpbuild build RPI_PICO2 RISCV
 
 # Standard case
 mpbuild build PYBV11
+mpbuild build ESP8266_GENERIC
 
 # Special case: Variant
 mpbuild build PYBV11 THREAD

--- a/tests/test_build_some_variants.sh
+++ b/tests/test_build_some_variants.sh
@@ -1,0 +1,48 @@
+#
+# Compile some microptyhon firmware.
+#
+# If the environment variable 'MICROPY_DIR' is set, it should point
+# to the ports directory of the micropython repository.
+#
+set -eox pipefail # https://www.youtube.com/watch?v=9fSkygQ-ZjI
+
+if [ -n "$MICROPY_DIR" ]; then
+  # This might be dangerous for firmware developers: All changes to the micropython repo will be undone!
+  git -C $MICROPY_DIR clean -fXd
+
+  cd $MICROPY_DIR
+fi
+
+
+if [ ! -d "`pwd`/ports/renesas-ra" ]; then
+  echo "`pwd`/ports/renesas-ra does NOT exist. Please make 'MICROPY_DIR' to point to the micropython ports directory."
+  exit 1
+fi
+
+mpbuild list
+
+# Standard case
+mpbuild build RPI_PICO2
+
+# Special case: Variant uses another build container
+mpbuild build RPI_PICO2 RISCV
+
+# Standard case
+mpbuild build PYBV11
+
+# Special case: Variant
+mpbuild build PYBV11 THREAD
+
+# Special case: Unix
+mpbuild build unix
+mpbuild build unix minimal
+
+# Special case: Webassembly
+# mpbuild build webassembly
+# mpbuild build webassembly standard
+
+# Special case: Windows
+# mpbuild build windows
+# mpbuild build windows dev
+# mpbuild build windows standard
+


### PR DESCRIPTION
# Summary

The functionality of `mpbuild` has not changed at all.

I added a API which allows to call `mpbuild` from octoprobe.

Notable internal change: stderr/stdout:

The existing code wrote to stderr/stdout and raised SystemExit: This is unwanted for a API as octoprobe uses python logging. Therefor I refactured the code to separate the CLI code (with stderr/stdout, SystemExit) and the code which justs works silent or raises an exception.

Notable internal change: default variant:
* Before: The default variant did not exist as a variant-object
* Now: Also the default variant is a variant-object with the flag 'default_variant' set.
* Rationale: Now every micropython-build IS a variant. I could remove many `if`s.

Notable internal change: `physical_board`:
* The `Board` class got an attribute `physical_board` which allows to distinguish between 'stm32' and 'unix'.

## The API (src/mpbuild/build_api.py)
* Throws an `MpbuildException` on failure
* Interface: `def build_by_variant(variant: Variant, do_clean: bool) -> Firmware`
* Returns the firmware filename on success

## This PR was tested on:
* Linux
* Python 3.12.2
* Docker ARM: https://github.com/mattytrentini/build-micropython-arm-docker/tree/update_to_bookworm
* Docker RP2: https://github.com/hmaerki/build-micropython-rp2350riscv-docker

## Tests where added
* See `tests/README.md`.
* All tests succeed