### PR TITLE
Introduce mpbuild api to be used by octoprobe (2)

### DIFF
--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -59,6 +59,11 @@ class Board:
     """
     Example: "PYBV11"
     """
+    directory: Path
+    """
+    The directory of the source code.
+    Example: ".../ports/esp32"
+    """
     variants: list[Variant]
     """
     List of variants available for this board.
@@ -100,6 +105,7 @@ class Board:
 
         board = Board(
             name=filename_json.parent.name,
+            directory=filename_json.parent,
             variants=[],
             url=board_json["url"],
             mcu=board_json["mcu"],
@@ -112,6 +118,10 @@ class Board:
             sorted([Variant(*v, board) for v in board_json.get("variants", {}).items()])
         )
         return board
+
+    @property
+    def deploy_filename(self) -> Path:
+        return self.directory / self.deploy[0]
 
 
 @dataclass(order=True)
@@ -172,14 +182,15 @@ class Database:
                 var.name for var in path.glob("variants/*") if var.is_dir()
             ]
             board = Board(
-                special_port_name,
-                [],
-                f"https://github.com/micropython/micropython/blob/master/ports/{special_port_name}/README.md",
-                "",
-                "",
-                "",
-                [],
-                [],
+                name=special_port_name,
+                directory=path,
+                variants=[],
+                url=f"https://github.com/micropython/micropython/blob/master/ports/{special_port_name}/README.md",
+                mcu="",
+                product="",
+                vendor="",
+                images=[],
+                deploy=[],
             )
             board.variants = [Variant(v, "", board) for v in variant_names]
             port = Port(special_port_name, {special_port_name: board})

--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -141,7 +141,7 @@ class Database:
     def __post_init__(self) -> None:
         mpy_dir = self.mpy_root_directory
         # Take care to avoid using Path.glob! Performance was 15x slower.
-        for p in glob(f"{mpy_dir}/ports/**/boards/**/board.json"):
+        for p in glob(f"{mpy_dir}/ports/*/boards/*/board.json"):
             filename_json = Path(p)
             port_name = filename_json.parent.parent.parent.name
             if self.port_filter and self.port_filter != port_name:

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -123,21 +123,8 @@ def build_board(
     #    >>> len(db.boards())
     #    169  # 3x boards are the 'special' boards without deployment instructions.
     if _board.deploy and "clean" not in extra_args:
-        deploy_filename = Path(
-            "/".join(
-                [
-                    str(mpy_dir),
-                    "ports",
-                    _board.port.name,
-                    "boards",
-                    _board.name,
-                    _board.deploy[0],
-                ]
-            )
-        )
-        if deploy_filename.is_file():
-            with open(deploy_filename) as deployfile:
-                print(Panel(Markdown(deployfile.read())))
+        if _board.deploy_filename.is_file():
+            print(Panel(Markdown(_board.deploy_filename.read_text())))
 
 
 def clean_board(

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -35,7 +35,7 @@ def build_board(
     build_container_override: Optional[str] = None,
     idf: Optional[str] = IDF_DEFAULT,
     mpy_dir: str|Path|None = None,
-) -> None:
+) -> pathlib.Path:
     # mpy_dir = mpy_dir or Path.cwd()
     # mpy_dir = Path(mpy_dir)
     mpy_dir, _ = find_mpy_root(mpy_dir)
@@ -51,7 +51,6 @@ def build_board(
     if variant and variant not in [v.name for v in _board.variants]:
         print("Invalid variant")
         raise SystemExit()
-
     if port not in BUILD_CONTAINERS.keys():
         print(f"Sorry, builds are not supported for the {port} port at this time")
         raise SystemExit()
@@ -113,7 +112,11 @@ def build_board(
     title += f" {port}/{board}" + (f" ({variant})" if variant else "")
     print(Panel(build_cmd, title=title, title_align="left", padding=1))
 
-    subprocess.run(build_cmd, shell=True)
+    proc = subprocess.run(build_cmd, shell=True, check=False)
+
+    if proc.returncode != 0:
+        print(f"ERROR: The following command returned {proc.returncode}: {build_cmd}")
+        raise SystemExit(proc.returncode)
 
     # Display deployment markdown
     # Note: Only displaying the first deploy file.

--- a/src/mpbuild/find_boards.py
+++ b/src/mpbuild/find_boards.py
@@ -4,13 +4,13 @@ from functools import cache
 
 
 @cache
-def find_mpy_root(root: str| Path | None = None):
+def find_mpy_root(root: str| Path | None = None) -> tuple[Path, str]:
     if root is None:
         root = Path(os.environ.get("MICROPY_DIR", ".")).resolve()
     else:
         root = Path(root)
 
-    port = None
+    port = ""
     while True:
         # If run from a port folder, store that for use in filters
         if root.parent.name == "ports":


### PR DESCRIPTION
This PR will supersede https://github.com/mattytrentini/mpbuild/pull/48

# Summary

The functionality of `mpbuild` has not changed at all.

I added a API which allows to call `mpbuild` from octoprobe.

Notable internal change: stderr/stdout:

The existing code wrote to stderr/stdout and raised SystemExit: This is unwanted for a API as octoprobe uses python logging. Therefor I refactured the code to separate the CLI code (with stderr/stdout, SystemExit) and the code which justs works silent or raises an exception.

Notable internal change: `physical_board`:
* The `Board` class got an attribute `physical_board` which allows to distinguish between 'stm32' and 'unix'.

## The API (src/mpbuild/build_api.py)
* NOTE: build_api.py was removed from this PR
* Throws an `MpbuildException` on failure
* Interface: `def build_by_variant(variant: Variant, do_clean: bool) -> Firmware`
* Returns the firmware filename on success

## This PR was tested on:
* Linux
* Python 3.12.2
* Every port was tested with a few boards and variants