### PR TITLE
Fix container selection for RPI_PICO2_W

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mpbuild"
-version = "0.6"
+version = "0.7"
 description = "Build MicroPython firmware with ease!"
 authors = [
     { name = "Matt Trentini", email = "matt.trentini@gmail.com" }

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -39,7 +39,7 @@ def get_build_container(board: Board, variant: Optional[str] = None) -> str:
     """
     port = board.port
 
-    if board.name == "RPI_PICO2":
+    if port.name == "rp2":
         if variant == "RISCV":
             # Special case: This board supports an ARM core as default
             # and a RISC-V core as a variant


### PR DESCRIPTION
Compiling RPI_PICO2_W failed as the wrong container was selected.

This is fixed in this PR.