### PR TITLE
extra_args can not be specified if variant is default

### DIFF
--- a/src/mpbuild/cli.py
+++ b/src/mpbuild/cli.py
@@ -57,6 +57,8 @@ def build(
     """
     Build a MicroPython board.
     """
+    if variant == "":
+        variant = None
     build_board(board, variant, extra_args or [], build_container, idf)
 
 


### PR DESCRIPTION
* Observed behaviour:

  `mpbuild build ESP32_GENERIC_S3 '' submodules`
    mpbuild fails with: `Invalid variant ''`

* Expected behaviour: No error

This PR fixes this issue