### PR TITLE
Pin IDF_DEFAULT to v5.3.1

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -54,7 +54,7 @@ def get_build_container(board: Board, variant: Optional[str] = None) -> str:
         raise MpbuildNotSupportedException(f"{board.name}-{variant}") from e
 
 
-IDF_DEFAULT = "v5.2.2"
+IDF_DEFAULT = "v5.3.1"
 
 nprocs = multiprocessing.cpu_count()
 


### PR DESCRIPTION
# Observation

Building `ESP32_GENERIC_S3`, `ESP32_GENERIC_S2` and probably others fail.

# Fix

* Fix micropython: https://github.com/micropython/micropython/pull/16530
* Fix mpbuild: IDF_DEFAULT v5.2.2 -> v5.3.1.

## Rationale

* IDF_DEFAULT v5.2.2 is too old and fails with the S2/S3 boards.
* IDF_DEFAULT v5.4 is fails currently on micropython-master with `py/persistentcode.c:439:38: error: 'prelude_ptr' may be used uninitialized [-Werror=maybe-uninitialized]`

# Test

I tested all ESP32 builds with this fix applied (all builds returned with rc=0):
```
set -euox pipefail

git clean -fxd; mpbuild build ARDUINO_NANO_ESP32 
git clean -fxd; mpbuild build ESP32_GENERIC 
git clean -fxd; mpbuild build ESP32_GENERIC D2WD
git clean -fxd; mpbuild build ESP32_GENERIC OTA
git clean -fxd; mpbuild build ESP32_GENERIC SPIRAM
git clean -fxd; mpbuild build ESP32_GENERIC UNICORE
git clean -fxd; mpbuild build ESP32_GENERIC_C3 
git clean -fxd; mpbuild build ESP32_GENERIC_C6 
git clean -fxd; mpbuild build ESP32_GENERIC_S2 
git clean -fxd; mpbuild build ESP32_GENERIC_S3 
git clean -fxd; mpbuild build ESP32_GENERIC FLASH_4M
git clean -fxd; mpbuild build ESP32_GENERIC SPIRAM_OCT
git clean -fxd; mpbuild build OLIMEX_ESP32_EVB 
git clean -fxd; mpbuild build OLIMEX_ESP32_POE
git clean -fxd; mpbuild build ESP8266_GENERIC
git clean -fxd; mpbuild build ESP8266_GENERIC FLASH_1M
git clean -fxd; mpbuild build ESP8266_GENERIC FLASH_512K
```

*Important: Run these builds against https://github.com/hmaerki/fork_micropython@fix_build_ESP32_GENERIC_S3*

micropython-master will fail!


