### PR TITLE
remove BOARD parameter from 'make submodules'

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -98,9 +98,7 @@ def docker_build_cmd(
     args = " " + " ".join(extra_args)
 
     make_mpy_cross_cmd = "make -C mpy-cross && "
-    update_submodules_cmd = (
-        f"make -C ports/{port.name} submodules BOARD={board.name}{variant_cmd} && "
-    )
+    update_submodules_cmd = f"make -C ports/{port.name} submodules && "
 
     uid, gid = os.getuid(), os.getgid()
 


### PR DESCRIPTION
## Observation A

`mpbuild build ESP32_GENERIC_S3` failes with
```
CMake Error at /opt/esp/idf/tools/cmake/build.cmake:544 (message):
  ERROR: Some components (espressif/tinyusb) in the "managed_components"
  directory were modified on the disk since the last run of the CMake.
  Content of this directory is managed automatically.
```

## Observation B

In mpbuild 'make submodules' is called with the BOARD parameter. According to the micropython build documentation this is wrong.

## Fix

Remove BOARD parameter fro 'make submodules'.

## Tests

I tested these builds (they compiled, eg. the return code was 0)

```bash
set -euox pipefail

git clean -fxd; mpbuild build RPI_PICO2
git clean -fxd; mpbuild build RPI_PICO2 RISCV
git clean -fxd; mpbuild build PYBV11
git clean -fxd; mpbuild build ESP8266_GENERIC
git clean -fxd; mpbuild build ESP32_GENERIC_S3 # Build fails on 1.14.1
git clean -fxd; mpbuild build PYBV11 THREAD
git clean -fxd; mpbuild build ESP8266_GENERIC-FLASH_512K
git clean -fxd; mpbuild build unix
git clean -fxd; mpbuild build unix minimal
git clean -fxd; mpbuild build ARDUINO_NANO_ESP32 
git clean -fxd; mpbuild build ESP32_GENERIC 
git clean -fxd; mpbuild build ESP32_GENERIC D2WD
git clean -fxd; mpbuild build ESP32_GENERIC OTA
git clean -fxd; mpbuild build ESP32_GENERIC SPIRAM
git clean -fxd; mpbuild build ESP32_GENERIC UNICORE
git clean -fxd; mpbuild build ESP32_GENERIC_C3 
git clean -fxd; mpbuild build ESP32_GENERIC_C6 
git clean -fxd; mpbuild build ESP32_GENERIC_S2 
git clean -fxd; mpbuild build ESP32_GENERIC_S3 
git clean -fxd; mpbuild build ESP32_GENERIC FLASH_4M
git clean -fxd; mpbuild build ESP32_GENERIC SPIRAM_OCT
git clean -fxd; mpbuild build OLIMEX_ESP32_EVB 
git clean -fxd; mpbuild build OLIMEX_ESP32_POE
git clean -fxd; mpbuild build ESP8266_GENERIC
git clean -fxd; mpbuild build ESP8266_GENERIC FLASH_1M
git clean -fxd; mpbuild build ESP8266_GENERIC FLASH_512K
```
