### PR TITLE
Remove IDF_DEFAULT - fixup

### DIFF
--- a/src/mpbuild/cli.py
+++ b/src/mpbuild/cli.py
@@ -55,7 +55,7 @@ def build(
     """
     if variant == "":
         variant = None
-    build_board(board, variant, extra_args or [], build_container, idf)
+    build_board(board, variant, extra_args or [], build_container)
 
 
 @app.command()


### PR DESCRIPTION
# Error

`mpbuild build RPI_PICO2`

Traceback
NameError: name 'idf' is not defined


# Fix

In https://github.com/mattytrentini/mpbuild/pull/60, we removed the 'idf' parameter.

But one occasion was overlooked and this PR fixes it.