### PR TITLE
add BOARD parameter from 'make submodules'

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -90,7 +90,7 @@ def docker_build_cmd(
     args = " " + " ".join(extra_args)
 
     make_mpy_cross_cmd = "make -C mpy-cross && "
-    update_submodules_cmd = f"make -C ports/{port.name} submodules && "
+    update_submodules_cmd = f"make -C ports/{port.name} BOARD={board.name}{variant_cmd} submodules && "
 
     uid, gid = os.getuid(), os.getgid()
 


### PR DESCRIPTION
## Error

`mpbuild build RPI_PICO2 RISCV`

fails with

```
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
Updating submodules: 
# If you see this error, it may mean the internal step run by the port's build
# system to find git submodules has failed. Double-check dependencies are set correctly.
Internal build error: The submodule list should not be empty.
```

I modified the Makefile to see the error leading to above error

```
Target board (PICO_BOARD) is 'pico'.
Using board configuration from /home/maerki/gits/micropython/lib/pico-sdk/src/boards/include/boards/pico.h
Pico Platform (PICO_PLATFORM) is 'rp2040'.
Defaulting compiler (PICO_COMPILER) to 'pico_arm_cortex_m0plus_gcc' since not specified.
Configuring toolchain based on PICO_COMPILER 'pico_arm_cortex_m0plus_gcc'
CMake Error at /home/maerki/gits/micropython/lib/pico-sdk/cmake/preload/toolchains/util/find_compiler.cmake:29 (message):
  Compiler 'arm-none-eabi-gcc' not found, you can specify search path with
  "PICO_TOOLCHAIN_PATH".
```

## Background

In #61, I proposed to remove the BOARD parameter from 'make submodules' as the micropython documentation proposes to do so.

However, it turned out that there is an exception which REQUIRES the BOARD parameter: RPI_PICO2-RISCV.

In #61 I mentioned the tests I did a that time. Why didn't I see that 'RPI_PICO2-RISCV' failed at that time?

## Fix

Add BOARD parameter for 'make submodules' again.

## Tests

I tested these builds (they compiled, eg. the return code was 0)

```bash
set -euox pipefail

git clean -fxd; mpbuild build RPI_PICO2
git clean -fxd; mpbuild build RPI_PICO2 RISCV
git clean -fxd; mpbuild build PYBV11
git clean -fxd; mpbuild build ESP8266_GENERIC
git clean -fxd; mpbuild build ESP32_GENERIC_S3 # Build fails on 1.14.1
git clean -fxd; mpbuild build PYBV11 THREAD
git clean -fxd; mpbuild build ESP8266_GENERIC-FLASH_512K
git clean -fxd; mpbuild build unix
git clean -fxd; mpbuild build unix minimal
git clean -fxd; mpbuild build ARDUINO_NANO_ESP32 
git clean -fxd; mpbuild build ESP32_GENERIC 
git clean -fxd; mpbuild build ESP32_GENERIC D2WD
git clean -fxd; mpbuild build ESP32_GENERIC OTA
git clean -fxd; mpbuild build ESP32_GENERIC SPIRAM
git clean -fxd; mpbuild build ESP32_GENERIC UNICORE
git clean -fxd; mpbuild build ESP32_GENERIC_C3 
git clean -fxd; mpbuild build ESP32_GENERIC_C6 
git clean -fxd; mpbuild build ESP32_GENERIC_S2 
git clean -fxd; mpbuild build ESP32_GENERIC_S3 
git clean -fxd; mpbuild build ESP32_GENERIC FLASH_4M
git clean -fxd; mpbuild build ESP32_GENERIC SPIRAM_OCT
git clean -fxd; mpbuild build OLIMEX_ESP32_EVB 
git clean -fxd; mpbuild build OLIMEX_ESP32_POE
git clean -fxd; mpbuild build ESP8266_GENERIC
git clean -fxd; mpbuild build ESP8266_GENERIC FLASH_1M
git clean -fxd; mpbuild build ESP8266_GENERIC FLASH_512K
```
