### PR TITLE
Handle when the url key is not present in board.json

### DIFF
--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -110,7 +110,7 @@ class Board:
         board = Board(
             name=filename_json.parent.name,
             variants=[],
-            url=board_json["url"],
+            url=board_json.get("url", "http://micropython.org"),
             mcu=board_json["mcu"],
             product=board_json["product"],
             vendor=board_json["vendor"],


### PR DESCRIPTION
As raised in #65, it was expected that `url` was always required in all `board.json` files. This fix (thanks @jonfitt!) uses the MicroPython URL if no `url` key is present.