### PR TITLE
board_database.py: 🪳Fix enumeration of special ports.

### DIFF
--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -34,10 +34,10 @@ provides a way to browse it's data.
 
 from __future__ import annotations
 
-from pathlib import Path
 import json
 from dataclasses import dataclass, field
 from glob import glob
+from pathlib import Path
 
 
 class MpbuildMpyDirectoryException(Exception):
@@ -159,6 +159,9 @@ class Board:
         for v in self.variants:
             if v.name == variant:
                 return v
+        print(
+            f"Variant '{variant}' not found for board '{self.name}': Valid variants are: {[v.name for v in self.variants]}"
+        )
 
         return None
 
@@ -239,7 +242,6 @@ class Database:
             port = Port(
                 name=special_port_name,
                 directory=path,
-                boards={special_port_name: board},
             )
             board = Board(
                 name=special_port_name,
@@ -253,10 +255,8 @@ class Database:
                 physical_board=False,
                 port=port,
             )
-            board.variants = [
-                Variant(name=v, text="", board=board) for v in variant_names
-            ]
-
+            port.boards = {special_port_name: board}
+            board.variants = [Variant(name=v, text="", board=board) for v in variant_names]
             self.ports[special_port_name] = port
             self.boards[board.name] = board
 


### PR DESCRIPTION
(cherry picked from commit 5155edc709574d817e6cbe2ec24a413017c8f89a)

Fix for `mpbuild list <special_port>`

```
│                                                                                                                                                                                                                                                                  │
│ /home/jos/mpbuild/src/mpbuild/board_database.py:242 in __post_init__                                                                                                                                                                                             │
│                                                                                                                                                                                                                                                                  │
│   239 │   │   │   port = Port(                                                                 ╭──────────────────────────────────────────────── locals ─────────────────────────────────────────────────╮                                                       │
│   240 │   │   │   │   name=special_port_name,                                                  │     filename_json = PosixPath('/home/jos/micropython/ports/renesas-ra/boards/RA4M1_CLICKER/board.json') │                                                       │
│   241 │   │   │   │   directory=path,                                                          │                 p = '/home/jos/micropython/ports/renesas-ra/boards/RA4M1_CLICKER/board.json'            │                                                       │
│ ❱ 242 │   │   │   │   boards={special_port_name: board},                                       │              path = PosixPath('/home/jos/micropython/ports/windows')                                    │                                                       │
│   243 │   │   │   )                                                                            │    port_directory = PosixPath('/home/jos/micropython/ports/renesas-ra')                                 │                                                       │
│   244 │   │   │   board = Board(                                                               │         port_name = 'renesas-ra'                                                                        │                                                       │
│   245 │   │   │   │   name=special_port_name,                                                  │              self = Database(ports={}, boards={})                                                       │                                                       │
│                                                                                                │ special_port_name = 'windows'                                                                           │                                                       │
│                                                                                                │     variant_names = ['dev', 'standard']                                                                 │                                                       │
│                                                                                                ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────╯                                                       │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
UnboundLocalError: local variable 'board' referenced before assignment
```

also incorrect listing of special port during normal list 
```
$ mpbuild list
🐍 MicroPython Boards
├── cc3200   1
│   └── WIPY 
├── esp32   29
│   ├── ARDUINO_NANO_ESP32 
│   ├── ESP32_GENERIC  D2WD, OTA, SPIRAM, UNICORE
...
│   ├── VCC_GND_F407VE 
│   ├── VCC_GND_F407ZG 
│   ├── VCC_GND_H743VI 
│   └── WEACT_F411_BLACKPILL  V13, V13_FLASH_4M, V20_FLASH_4M, V31_FLASH_8M, V31_XTAL_8M
├── unix   1
│   └── RA4M1_CLICKER 
├── webassembly   1
│   └── unix  coverage, standard, nanbox, minimal
└── windows   1
    └── webassembly  pyscript, standard

```