### PR TITLE
Build webassembly and windows ports

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -3,8 +3,6 @@ import multiprocessing
 import os
 import re
 import subprocess
-from pathlib import Path
-from typing import List, Optional
 import sys
 from pathlib import Path
 
@@ -195,7 +193,9 @@ def docker_build_cmd(
             )
 
     build_container = (
-        build_container_override if build_container_override else get_build_container(board=board, variant=variant)
+        build_container_override
+        if build_container_override
+        else get_build_container(board=board, variant=variant)
     )
 
     variant_param = "BOARD_VARIANT" if board.physical_board else "VARIANT"
@@ -255,10 +255,10 @@ def docker_build_cmd(
         f"{build_container} "
         f'bash -c "'
         f"git config --global --add safe.directory '*' 2> /dev/null;"
-        f'{ci_setup_cmd}'
-        f'{ci_environment_cmd}'
-        f'{make_mpy_cross_cmd}'
-        f'{update_submodules_cmd}'
+        f"{ci_setup_cmd}"
+        f"{ci_environment_cmd}"
+        f"{make_mpy_cross_cmd}"
+        f"{update_submodules_cmd}"
         f'make -j {nprocs} -C ports/{port.name} BOARD={board.name}{variant_cmd}{args}"'
     )
 

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -14,6 +14,7 @@ from . import board_database, find_mpy_root
 from .board_database import Board
 
 ARM_BUILD_CONTAINER = "micropython/build-micropython-arm"
+WIN_BUILD_CONTAINER = "micropython/build-micropython-win-mingw:latest"
 ESP_IDF_CONTAINER = "espressif/idf"
 ESP_IDF_FALLBACK_VERSION = "v5.4.2"
 BUILD_CONTAINERS = {
@@ -27,6 +28,8 @@ BUILD_CONTAINERS = {
     "esp32": f"{ESP_IDF_CONTAINER}:{ESP_IDF_FALLBACK_VERSION}",
     "esp8266": "larsks/esp-open-sdk",
     "unix": "gcc:12-bookworm",  # Special, doesn't have boards
+    "webassembly": ARM_BUILD_CONTAINER,  # installs emsdk on first build
+    "windows": WIN_BUILD_CONTAINER,  # cross compile linux to windows
 }
 
 
@@ -199,6 +202,14 @@ def docker_build_cmd(
     variant_param = "BOARD_VARIANT" if board.physical_board else "VARIANT"
     variant_cmd = "" if variant is None else f" {variant_param}={variant}"
 
+    ci_environment_cmd = ""
+    ci_setup_cmd = ""
+    if port.name == "webassembly":
+        ci_setup_cmd = "source tools/ci.sh; ci_webassembly_setup;"
+        ci_environment_cmd = 'source "emsdk/emsdk_env.sh";'
+    elif port.name == "windows":
+        extra_args = ["CROSS_COMPILE=i686-w64-mingw32-"] + extra_args
+
     args = " " + " ".join(extra_args)
 
     make_mpy_cross_cmd = "make -C mpy-cross && "
@@ -213,6 +224,8 @@ def docker_build_cmd(
         # Don't need to build mpy_cross or update submodules
         make_mpy_cross_cmd = ""
         update_submodules_cmd = ""
+        ci_environment_cmd = ""
+        ci_setup_cmd = ""
 
     mpy_dir = str(port.directory_repo)
 
@@ -243,6 +256,8 @@ def docker_build_cmd(
         f"{build_container} "
         f'bash -c "'
         f"git config --global --add safe.directory '*' 2> /dev/null;"
+        f"{ci_setup_cmd}"
+        f"{ci_environment_cmd}"
         f"{make_mpy_cross_cmd}"
         f"{update_submodules_cmd}"
         f'make -j {nprocs} -C ports/{port.name} BOARD={board.name}{variant_cmd}{args}"'

--- a/tests/test_build_container.py
+++ b/tests/test_build_container.py
@@ -52,12 +52,28 @@ class TestSimplePorts:
         db = Database(mpy_root)
         assert get_build_container(db.boards["unix"]) == "gcc:12-bookworm"
 
-    def test_unsupported_port_raises(self, mpy_root):
-        """Ports not in BUILD_CONTAINERS raise MpbuildNotSupportedException."""
-        # 'webassembly' is auto-added as a special port but is not in BUILD_CONTAINERS.
+    def test_webassembly_special_port(self, mpy_root):
+        """The 'webassembly' special port reuses the ARM build container; emsdk
+        is installed at build time via tools/ci.sh."""
         db = Database(mpy_root)
-        with pytest.raises(MpbuildNotSupportedException, match="webassembly"):
-            get_build_container(db.boards["webassembly"])
+        assert get_build_container(db.boards["webassembly"]) == ARM_BUILD_CONTAINER
+
+    def test_windows_special_port(self, mpy_root):
+        """The 'windows' special port resolves to the MinGW cross-compile container."""
+        db = Database(mpy_root)
+        assert (
+            get_build_container(db.boards["windows"]) == "micropython/build-micropython-win-mingw"
+        )
+
+    def test_unsupported_port_raises(self, mpy_root, make_board):
+        """Ports not in BUILD_CONTAINERS raise MpbuildNotSupportedException."""
+        # Synthesize a port name that isn't in BUILD_CONTAINERS. (All three
+        # 'special' ports — unix/webassembly/windows — are supported, so we
+        # can't use them here.)
+        make_board("qemu", "QEMU_BOARD", mcu="qemu")
+        db = Database(mpy_root)
+        with pytest.raises(MpbuildNotSupportedException, match="QEMU_BOARD"):
+            get_build_container(db.boards["QEMU_BOARD"])
 
 
 # ===================================================================

--- a/tests/test_build_container.py
+++ b/tests/test_build_container.py
@@ -66,10 +66,13 @@ class TestSimplePorts:
 
     def test_unsupported_port_raises(self, mpy_root, make_board):
         """Ports not in BUILD_CONTAINERS raise MpbuildNotSupportedException."""
-        # 'webassembly' is auto-added as a special port but is not in BUILD_CONTAINERS.
+        # Synthesize a port name that isn't in BUILD_CONTAINERS. (All three
+        # 'special' ports — unix/webassembly/windows — are supported, so we
+        # can't use them here.)
+        make_board("qemu", "QEMU_BOARD", mcu="qemu")
         db = Database(mpy_root)
-        with pytest.raises(MpbuildNotSupportedException, match="webassembly"):
-            get_build_container(db.boards["webassembly"])
+        with pytest.raises(MpbuildNotSupportedException, match="QEMU_BOARD"):
+            get_build_container(db.boards["QEMU_BOARD"])
 
 
 # ===================================================================

--- a/tests/test_build_container.py
+++ b/tests/test_build_container.py
@@ -9,6 +9,7 @@ from mpbuild.build import (
     ARM_BUILD_CONTAINER,
     ESP_IDF_CONTAINER,
     ESP_IDF_FALLBACK_VERSION,
+    WIN_BUILD_CONTAINER,
     MpbuildNotSupportedException,
     get_build_container,
 )
@@ -52,7 +53,18 @@ class TestSimplePorts:
         db = Database(mpy_root)
         assert get_build_container(db.boards["unix"]) == "gcc:12-bookworm"
 
-    def test_unsupported_port_raises(self, mpy_root):
+    def test_webassembly_special_port(self, mpy_root):
+        """The 'webassembly' special port reuses the ARM build container; emsdk
+        is installed at build time via tools/ci.sh."""
+        db = Database(mpy_root)
+        assert get_build_container(db.boards["webassembly"]) == ARM_BUILD_CONTAINER
+
+    def test_windows_special_port(self, mpy_root):
+        """The 'windows' special port resolves to the MinGW cross-compile container."""
+        db = Database(mpy_root)
+        assert get_build_container(db.boards["windows"]) == WIN_BUILD_CONTAINER
+
+    def test_unsupported_port_raises(self, mpy_root, make_board):
         """Ports not in BUILD_CONTAINERS raise MpbuildNotSupportedException."""
         # 'webassembly' is auto-added as a special port but is not in BUILD_CONTAINERS.
         db = Database(mpy_root)


### PR DESCRIPTION
This pull request includes several changes to add support for building MicroPython for webassembly and windows 

### WebAssembly is supported using the `ARM_BUILD_CONTAINER` :
- The `emsdk` toolchain is installed during the first build using the `tools/ci.sh` script that is used to run the integration tests for MicroPython. 
- after the first build the `emsdk` toolchain is cached and used for subsequent builds.

### Windows is supported using the MinGW toolchain:
- The windows build uses the container definition `micropython/build-micropython-win-mingw`. It uses the same build process as the official MicroPython Docker container, but with the MinGW toolchain instead of the ARM toolchain.
- This container is not yet published, but can be built locally from the `containers/build-micropython-win-mingw` directory

### Build process improvements:

* [`src/mpbuild/build.py`](diffhunk://#diff-6eaf589a9a48d7ebbcba50f9ed067cff680809878db488b64551535f2630b299R25-R26): Added support for the new MinGW build container and updated the build command to handle special cases for `webassembly` and `windows` ports. This includes setting up the CI environment and adding cross-compilation arguments for Windows. [[1]](diffhunk://#diff-6eaf589a9a48d7ebbcba50f9ed067cff680809878db488b64551535f2630b299R25-R26) [[2]](diffhunk://#diff-6eaf589a9a48d7ebbcba50f9ed067cff680809878db488b64551535f2630b299L82-R96) [[3]](diffhunk://#diff-6eaf589a9a48d7ebbcba50f9ed067cff680809878db488b64551535f2630b299R110-R111) [[4]](diffhunk://#diff-6eaf589a9a48d7ebbcba50f9ed067cff680809878db488b64551535f2630b299R129-R130)

### Code cleanup and refactoring:
* [`src/mpbuild/board_database.py`](diffhunk://#diff-c97385d3f93b0bc006eb66b01efd99e2a869b7b512795c2fff8149ceda5ccedeL37-R40): Moved the import of `Path` to the top of the file for consistency and added a print statement to provide more information when a variant is not found. [[1]](diffhunk://#diff-c97385d3f93b0bc006eb66b01efd99e2a869b7b512795c2fff8149ceda5ccedeL37-R40) [[2]](diffhunk://#diff-c97385d3f93b0bc006eb66b01efd99e2a869b7b512795c2fff8149ceda5ccedeR162-R164)

### Depends on 

Never mind - merged already
