### PR TITLE
fix: deploy_filename errors when no deployment.md is found.

### DIFF
--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -143,11 +143,11 @@ class Board:
         return directory_
 
     @property
-    def deploy_filename(self) -> Path:
+    def deploy_filename(self) -> Path | None:
         """
-        Returns the filename of the deploy-markdown.
+        Returns the filename of the deploy-markdown, or None.
         """
-        return self.directory / self.deploy[0]
+        return self.directory / self.deploy[0] if self.deploy else None
 
     # TODO(mst): Update Variant to allow comparisons to strings. This method can
     # then be removed.


### PR DESCRIPTION
Found while iterating over all boards.
An `IndexError: list index out of range` is raised when accessing `deploy_filename` for a board that has no deploy.md 

( unix, windows , webassembly) 
