### PR TITLE
Continue build if make submodules fails.

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -90,7 +90,7 @@ def docker_build_cmd(
     args = " " + " ".join(extra_args)
 
     make_mpy_cross_cmd = "make -C mpy-cross && "
-    update_submodules_cmd = f"make -C ports/{port.name} BOARD={board.name}{variant_cmd} submodules && "
+    update_submodules_cmd = f"make -C ports/{port.name} BOARD={board.name}{variant_cmd} submodules ; "
 
     uid, gid = os.getuid(), os.getgid()
 


### PR DESCRIPTION
Currently mpbuild includes `make submodules` before each build. This is usually a good thing however if this step fails for any reason it prevents the build from being attempted.

Very often during development I'll need to make changes to a submodule like micropython-lib.  Once any of the submodules are "unclean" like that, `make submodules` at the top level fails as `git submodules sync` expects a clean git tree. 

So in situations like this the git submodules step failing means I can't build firmware.

This PR still runs the make submodules exactly the same, but even if it fails it still lets the build progress; if the git submodules failure is legitimate the actual build will likely fail anyway.
