### PR TITLE
Change build/clean commands to use BOARD<-VARIANT> format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Build MicroPython firmware with ease!
 Build a board, with optional variant:
 
 ```bash
-mpbuild build BOARD [VARIANT]
+mpbuild build BOARD[-VARIANT]
 ```
 
 Remove build artifacts:
 
 ```bash
-mpbuild clean BOARD [VARIANT]
+mpbuild clean BOARD[-VARIANT]
 ```
 
 List the available boards, optionally filter by the port name.

--- a/src/mpbuild/cli.py
+++ b/src/mpbuild/cli.py
@@ -7,41 +7,16 @@ from . import __app_name__, __version__, OutputFormat
 from .build import build_board, clean_board
 from .list_boards import print_boards
 from .check_images import check_boards
-from .completions import list_ports, list_boards, list_variants_for_board
+from .completions import complete_port, complete_board_variant
 
 app = typer.Typer(chain=True, context_settings={"help_option_names": ["-h", "--help"]})
 
 
-def _complete(words: list[str], incomplete: str):
-    completion = []
-    for name in words:
-        if name.startswith(incomplete):
-            completion.append(name)
-    return completion
-
-
-def _complete_board(incomplete: str):
-    return _complete(list_boards(), incomplete)
-
-
-def _complete_variant(ctx: typer.Context, incomplete: str):
-    board = ctx.params.get("board") or []
-    return _complete(list_variants_for_board(board), incomplete)
-
-
-def _complete_port(incomplete: str):
-    return _complete(list_ports(), incomplete)
-
-
 @app.command()
 def build(
-    board: Annotated[
-        str, typer.Argument(help="Board name", autocompletion=_complete_board)
+    board_variant: Annotated[
+        str, typer.Argument(help="Board name or Board-Variant", autocompletion=complete_board_variant)
     ],
-    variant: Annotated[
-        Optional[str],
-        typer.Argument(help="Board variant", autocompletion=_complete_variant),
-    ] = None,
     extra_args: Annotated[
         Optional[List[str]], typer.Argument(help="additional arguments to pass to make")
     ] = None,
@@ -53,25 +28,38 @@ def build(
     """
     Build a MicroPython board.
     """
-    if variant == "":
+    # Parse the board and variant from the combined format
+    if "-" in board_variant:
+        board, variant = board_variant.split("-", 1)
+    else:
+        board = board_variant
         variant = None
     build_board(board, variant, extra_args or [], build_container)
 
 
 @app.command()
 def clean(
-    board: str, variant: Annotated[Optional[str], typer.Argument()] = None
+    board_variant: Annotated[
+        str, typer.Argument(help="Board name or Board-Variant", autocompletion=complete_board_variant)
+    ]
 ) -> None:
     """
     Clean a MicroPython board.
     """
+    # Parse the board and variant from the combined format
+    if "-" in board_variant:
+        board, variant = board_variant.split("-", 1)
+    else:
+        board = board_variant
+        variant = None
+    
     clean_board(board, variant)
 
 
 @app.command("list")
 def list_boards_and_variants(
     port: Annotated[
-        Optional[str], typer.Argument(help="Port name", autocompletion=_complete_port)
+        Optional[str], typer.Argument(help="Port name", autocompletion=complete_port)
     ] = None,
     fmt: Annotated[
         OutputFormat,

--- a/src/mpbuild/completions.py
+++ b/src/mpbuild/completions.py
@@ -15,3 +15,56 @@ def list_variants_for_board(board: str) -> list[str]:
     db = board_database()
     variants = db.boards[board].variants
     return [v.name for v in variants if v]
+
+
+def _complete(words: list[str], incomplete: str):
+    completion = []
+    for name in words:
+        if name.startswith(incomplete):
+            completion.append(name)
+    return completion
+
+
+def complete_board(incomplete: str):
+    return _complete(list_boards(), incomplete)
+
+
+def complete_board_variant(incomplete: str):
+    # If no dash yet, only complete board names
+    if "-" not in incomplete:
+        boards = complete_board(incomplete)
+        if incomplete in boards:
+            # Offer variant options as well
+            board = incomplete
+            variants = list_variants_for_board(board)
+            boards.extend([f"{board}-{v}" for v in variants])
+        
+        if len(boards) == 1:
+            board = boards[0]
+            if board != incomplete:
+                #  finish completing this board
+                variants = list_variants_for_board(board)
+                if variants:
+                    # There are possible variants, remove the
+                    # trailing space from the autocomplete
+                    # so the user can autocomplete the variant 
+                    # if desired
+                    boards[0] += r"\b"
+            else:
+                # board name complete, suggest variants (if any)
+                variants = list_variants_for_board(board)
+                return [f"{board}-{v}" for v in variants]
+        return boards
+    else:
+        # After board name, complete variants for the specified board
+        board, variant_part = incomplete.split("-", 1)
+    
+        if board in list_boards():
+            variants = list_variants_for_board(board)
+            if variants:
+                return [f"{board}-{v}" for v in variants if v.startswith(variant_part)]
+    return []
+
+
+def complete_port(incomplete: str):
+    return _complete(list_ports(), incomplete)


### PR DESCRIPTION
When boards have variants available in micropython, the resulting build / filename is in the form `<BOARD>-<VARIANT>-<date/version/etc>.hex`

Similarly micropython has recently had a feature added to query on device what it's build is: https://github.com/micropython/micropython/pull/16843
`>>> sys.implementation._build` will now return the build being run like `<BOARD>-<VARIANT>` for microcontroller ports (the variant is optional)

This PR modifies the build and clean cli commands to accept `<BOARD>-<VARIANT>` in the same format.

- Modify build and clean commands to use combined BOARD-VARIANT format instead of separate arguments
- Implement two-stage autocompletion: first suggest boards, then -VARIANT after a complete board name
- Update README.md to reflect new command format

In use this looks like:
![image](https://github.com/user-attachments/assets/d5e03506-f7dd-4747-b0c3-7a98c35ec336)

---
I used Claude Code to assist with this change, starting from the prompt:
```
╭───────────────────────────────────────────────────────────────────╮
│ > the tool supports the build command in the form `mpbuild build  │
│   BOARD VARIANT` where `VARIANT` is optional. Instead I'd like    │
│   `mpbuild build BOARD-VARIANT` where the `-VARIANT` is still     │
│   optional. I want autocomplete to only suggest the BOARD         │
│   portion first, only when a full existing `BOARD` is on the      │
│   command line should another tab key press start suggesting      │
│   possible `-VARIANT` options.                                    │
╰───────────────────────────────────────────────────────────────────╯
```