### PR TITLE
Use container /tmp as HOME.

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -113,7 +113,7 @@ def docker_build_cmd(
         f"--net=host --privileged "             # provides access to USB for deploy
         f"-v {mpy_dir}:{mpy_dir} -w {mpy_dir} " # mount micropython dir with same path so elf/map paths match host
         f"--user {uid}:{gid} "                  # match running user id so generated files aren't owned by root
-        f"-v {home}:{home} -e HOME={home} "     # when changing user id to one not present in container this ensures home is writable
+        f"-e HOME=/tmp "                        # when changing user id to one not present in container this ensures home is writable
         f"{build_container} "
         f'bash -c "'
         f"git config --global --add safe.directory '*' 2> /dev/null;"


### PR DESCRIPTION
Currently the users real home is passed into the container and used. This means that the git command to mark everything as safe is being set in the real user gitconfig which is a security issue.

Using the temp folder in the container ensures changes like this are ephemeral and limited to the build environment.