### PR TITLE
micropython reference moved to espressif/idf:v5.4.1

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -20,8 +20,8 @@ BUILD_CONTAINERS = {
     "mimxrt": ARM_BUILD_CONTAINER,
     "renesas-ra": ARM_BUILD_CONTAINER,
     "samd": ARM_BUILD_CONTAINER,
-    "esp32": "espressif/idf:v5.2.2",
     "psoc6": "ifxmakers/mpy-mtb-ci",
+    "esp32": "espressif/idf:v5.4.1",
     "esp8266": "larsks/esp-open-sdk",
     "unix": "gcc:12-bookworm",  # Special, doesn't have boards
 }


### PR DESCRIPTION
The micropython reference build has moved to v5.4.1, see https://github.com/micropython/micropython/commit/f48b9815671eb81e99339dc443fb20dca1c72e69.

This PR updates mpbuild to espressif/idf:v5.4.1.

## Tests

I could successfully compile all these boards:

```bash
#
# HOW TO USE
#
# 'cd' into a micropython repo
# and start this script.
#
# If the scripts runs to the end, all firmwares
# could be built successfully
#
set -euox pipefail

# export ARGS="--build-container=hmaerki/build-micropython-esp32:v5.2.2"
export ARGS=""

git clean -fxd; mpbuild build $ARGS ARDUINO_NANO_ESP32 
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC 
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC D2WD
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC OTA
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC SPIRAM
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC UNICORE
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC_C3 
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC_C6 
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC_S2 
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC_S3 
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC FLASH_4M
git clean -fxd; mpbuild build $ARGS ESP32_GENERIC SPIRAM_OCT
git clean -fxd; mpbuild build $ARGS OLIMEX_ESP32_EVB 
git clean -fxd; mpbuild build $ARGS OLIMEX_ESP32_POE
```