### PR TITLE
Add the PSOC build container

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -21,6 +21,7 @@ BUILD_CONTAINERS = {
     "renesas-ra": ARM_BUILD_CONTAINER,
     "samd": ARM_BUILD_CONTAINER,
     "esp32": "espressif/idf:v5.2.2",
+    "psoc6": "ifxmakers/mpy-mtb-ci",
     "esp8266": "larsks/esp-open-sdk",
     "unix": "gcc:12-bookworm",  # Special, doesn't have boards
 }
@@ -90,8 +91,9 @@ def docker_build_cmd(
     args = " " + " ".join(extra_args)
 
     make_mpy_cross_cmd = "make -C mpy-cross && "
-    update_submodules_cmd = f"make -C ports/{port.name} BOARD={board.name}{variant_cmd} submodules && "
-
+    update_submodules_cmd = (
+        f"make -C ports/{port.name} BOARD={board.name}{variant_cmd} submodules && "
+    )
     uid, gid = os.getuid(), os.getgid()
 
     if do_clean:


### PR DESCRIPTION
Just add a PSOC container to the list of supported build containers. Note that PSOC builds (see micropython/micropython#16705) don't currently successfully build even with this container since they require an additional make target (`mtb_init`). But this allows us to experiment with PSOC builds more easily with mpbuild.