### PR TITLE
docker_build_cmd() fails when devices dissapear

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -67,6 +67,7 @@ def docker_build_cmd(
     do_clean: bool = False,
     build_container_override: str | None = None,
     docker_interactive: bool = True,
+    add_device_flags: bool = True,
 ) -> str:
     """
     Returns the docker-command which will build the firmware.
@@ -107,17 +108,18 @@ def docker_build_cmd(
 
     mpy_dir = str(port.directory_repo)
 
-    # Dynamically find all ttyACM and ttyUSB devices
-    tty_devices = []
-    for pattern in ["/dev/ttyACM*", "/dev/ttyUSB*"]:
-        tty_devices.extend(glob.glob(pattern))
-
     # Build device flags
     device_flags = ""
-    if os.path.exists("/dev/bus/usb/") and os.listdir("/dev/bus/usb/"):
-        device_flags += "--device /dev/bus/usb/ "  # USB access
-    for device in tty_devices:
-        device_flags += f"--device {device} "
+    if add_device_flags:
+        # Dynamically find all ttyACM and ttyUSB devices
+        tty_devices = []
+        for pattern in ["/dev/ttyACM*", "/dev/ttyUSB*"]:
+            tty_devices.extend(glob.glob(pattern))
+
+        if os.path.exists("/dev/bus/usb/") and os.listdir("/dev/bus/usb/"):
+            device_flags += "--device /dev/bus/usb/ "  # USB access
+        for device in tty_devices:
+            device_flags += f"--device {device} "
 
     # fmt: off
     build_cmd = (

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -68,6 +68,7 @@ def docker_build_cmd(
     build_container_override: str | None = None,
     docker_interactive: bool = True,
     add_device_flags: bool = True,
+    submodules_add_board: bool = True,
 ) -> str:
     """
     Returns the docker-command which will build the firmware.
@@ -94,9 +95,10 @@ def docker_build_cmd(
     args = " " + " ".join(extra_args)
 
     make_mpy_cross_cmd = "make -C mpy-cross && "
-    update_submodules_cmd = (
-        f"make -C ports/{port.name} BOARD={board.name}{variant_cmd} submodules && "
-    )
+    update_submodules_cmd = f"make -C ports/{port.name}"
+    if submodules_add_board:
+        update_submodules_cmd += f" BOARD={board.name}{variant_cmd}"
+    update_submodules_cmd += " submodules && "
     uid, gid = os.getuid(), os.getgid()
 
     if do_clean:


### PR DESCRIPTION
# Error cause

I like https://github.com/mattytrentini/mpbuild/pull/78 very much - however, there is a negative side effect:

In Octoprobe, device come and go while testing. In parallel mpbuild is building firmware.

No while mpbuild is starting the docker container and at the same time a device dissapears, docker will fail. See log below.

## Fix

This PR adds a parameter: `def docker_build_cmd(add_device_flags=True)`.

The parameter is set to True by default, so mpbuild behaviour is not affected.

However, octoprobe will call `docker_build_cmd(add_device_flags=False)` and hence docker will not fail anymore.

## Error log from octoprobe

https://reports.octoprobe.org/github_selfhosted_testrun_63/mpbuild/ARDUINO_NANO_33_BLE_SENSE/docker_stdout.txt

```code
mpbuild build ARDUINO_NANO_33_BLE_SENSE
docker run --rm --device /dev/bus/usb/ --device /dev/ttyACM11 --device /dev/ttyACM18 --device /dev/ttyACM17 --device /dev/ttyACM16 --device /dev/ttyACM15 --device /dev/ttyACM14 --device /dev/ttyACM13 --device /dev/ttyACM12 --device /dev/ttyACM10 --device /dev/ttyACM9 --device /dev/ttyACM8 --device /dev/ttyACM7 --device /dev/ttyACM6 --device /dev/ttyACM5 --device /dev/ttyACM4 --device /dev/ttyACM3 --device /dev/ttyACM2 --device /dev/ttyACM1 --device /dev/ttyACM0 --device /dev/ttyUSB3 --device /dev/ttyUSB2 --device /dev/ttyUSB1 --device /dev/ttyUSB0 -v /home/githubrunner/octoprobe_downloads/git-cache/work/firmware_github-com-micropython-micropython:/home/githubrunner/octoprobe_downloads/git-cache/work/firmware_github-com-micropython-micropython -w /home/githubrunner/octoprobe_downloads/git-cache/work/firmware_github-com-micropython-micropython --user 1003:1003 -e HOME=/tmp micropython/build-micropython-arm bash -c "git config --global --add safe.directory '*' 2> /dev/null;make -C mpy-cross && make -C ports/nrf BOARD=ARDUINO_NANO_33_BLE_SENSE submodules && make -j 4 -C ports/nrf BOARD=ARDUINO_NANO_33_BLE_SENSE "

docker: Error response from daemon: error gathering device information while adding custom device "/dev/ttyACM17": no such file or directory.

returncode=127
```