### PR TITLE
Fix Docker builds for git worktrees

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -14,6 +14,81 @@ from rich.markdown import Markdown
 from . import board_database, find_mpy_root
 from .board_database import Board
 
+
+def get_git_directory(mpy_dir: Path) -> Path | None:
+    """
+    Get the actual .git directory path, handling both regular repos and worktrees.
+
+    Args:
+        mpy_dir: Path to the MicroPython repository root
+
+    Returns:
+        Path to the actual .git directory, or None if not found
+    """
+    git_path = mpy_dir / ".git"
+
+    if not git_path.exists():
+        return None
+
+    if git_path.is_dir():
+        # Regular git repository
+        return git_path
+    elif git_path.is_file():
+        # Git worktree - .git file contains path to actual .git directory
+        try:
+            git_file_content = git_path.read_text().strip()
+            if git_file_content.startswith("gitdir: "):
+                gitdir_path = git_file_content[8:]  # Remove "gitdir: " prefix
+                return Path(gitdir_path).resolve()
+        except (OSError, ValueError):
+            pass
+
+    return None
+
+
+def get_main_git_directory(mpy_dir: Path) -> Path | None:
+    """
+    Get the main .git directory for repos and worktrees.
+
+    For regular repos, returns None (no additional mount needed).
+    For worktrees, returns the common git directory that needs to be mounted.
+
+    Args:
+        mpy_dir: Path to the MicroPython repository root
+
+    Returns:
+        Path to the main .git directory, or None if not needed
+
+    Raises:
+        RuntimeError: If git command is not available
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=mpy_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            git_common_dir = Path(result.stdout.strip()).resolve()
+            if git_common_dir.exists() and git_common_dir.is_dir():
+                # If the git directory is already within mpy_dir, no mount needed
+                if git_common_dir.is_relative_to(mpy_dir):
+                    return None
+                return git_common_dir
+    except FileNotFoundError:
+        raise RuntimeError(
+            "Git command not found. Please install git to build with mpbuild."
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(
+            "Git command timed out. Check git installation and repository state."
+        )
+
+    return None
+
+
 ARM_BUILD_CONTAINER = "micropython/build-micropython-arm"
 BUILD_CONTAINERS = {
     "stm32": ARM_BUILD_CONTAINER,
@@ -107,6 +182,12 @@ def docker_build_cmd(
 
     mpy_dir = str(port.directory_repo)
 
+    # Handle git worktrees by mounting the main .git directory
+    git_volume_mount = ""
+    main_git_dir = get_main_git_directory(Path(mpy_dir))
+    if main_git_dir:
+        git_volume_mount = f"-v {main_git_dir}:{main_git_dir} "
+
     # Dynamically find all ttyACM and ttyUSB devices
     tty_devices = []
     for pattern in ["/dev/ttyACM*", "/dev/ttyUSB*"]:
@@ -125,6 +206,7 @@ def docker_build_cmd(
         f"{'-it ' if docker_interactive else ''}"
         f"{device_flags}"                       # provides access to USB and serial devices for deploy
         f"-v {mpy_dir}:{mpy_dir} -w {mpy_dir} " # mount micropython dir with same path so elf/map paths match host
+        f"{git_volume_mount}"                   # mount actual .git directory for worktrees
         f"--user {uid}:{gid} "                  # match running user id so generated files aren't owned by root
         f"-e HOME=/tmp "                        # set HOME to /tmp for container
         f"{build_container} "

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -13,6 +13,58 @@ from rich.panel import Panel
 from . import board_database, find_mpy_root
 from .board_database import Board
 
+
+def get_main_git_directory(mpy_dir: Path) -> Path | None:
+    """
+    Get the main .git directory for repos and worktrees.
+
+    For regular repos (where ``.git`` already lives inside ``mpy_dir``) this
+    returns ``None`` — no additional bind-mount is needed. For worktrees,
+    where the common git directory lives outside ``mpy_dir``, this returns
+    the absolute path of that common dir so the caller can mount it into the
+    docker container alongside ``mpy_dir``.
+
+    Args:
+        mpy_dir: Path to the MicroPython repository root.
+
+    Returns:
+        Path to the common .git directory if it sits outside ``mpy_dir``,
+        else None.
+
+    Raises:
+        RuntimeError: If git is not installed or the call times out.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=mpy_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            # git rev-parse --git-common-dir returns a path relative to the
+            # working tree for normal repos (just ".git") and an absolute path
+            # for worktrees. Anchor on mpy_dir before resolving so the relative
+            # case doesn't accidentally point at the caller's own .git.
+            git_common_dir = (Path(mpy_dir) / result.stdout.strip()).resolve()
+            if git_common_dir.exists() and git_common_dir.is_dir():
+                # If the git directory is already within mpy_dir, no mount needed
+                if git_common_dir.is_relative_to(Path(mpy_dir).resolve()):
+                    return None
+                return git_common_dir
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "Git command not found. Please install git to build with mpbuild."
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            "Git command timed out. Check git installation and repository state."
+        ) from e
+
+    return None
+
+
 ARM_BUILD_CONTAINER = "micropython/build-micropython-arm"
 WIN_BUILD_CONTAINER = "micropython/build-micropython-win-mingw:latest"
 ESP_IDF_CONTAINER = "espressif/idf"
@@ -229,6 +281,12 @@ def docker_build_cmd(
 
     mpy_dir = str(port.directory_repo)
 
+    # Handle git worktrees by mounting the main .git directory
+    git_volume_mount = ""
+    main_git_dir = get_main_git_directory(Path(mpy_dir))
+    if main_git_dir:
+        git_volume_mount = f"-v {main_git_dir}:{main_git_dir} "
+
     # Dynamically find all ttyACM and ttyUSB devices
     tty_devices = []
     for pattern in ["/dev/ttyACM*", "/dev/ttyUSB*"]:
@@ -244,6 +302,7 @@ def docker_build_cmd(
     # Build the docker run invocation. Each option, in order:
     #   {device_flags}             USB and serial devices for deploy
     #   -v <mpy>:<mpy> -w <mpy>    mount mpy dir at same path so elf/map paths match host
+    #   {git_volume_mount}         mount common .git dir when building from a worktree
     #   --user <uid>:<gid>         match host user id so generated files aren't owned by root
     #   -e HOME=/tmp               set HOME to /tmp for the container
     build_cmd = (
@@ -251,6 +310,7 @@ def docker_build_cmd(
         f"{'-it ' if docker_interactive else ''}"
         f"{device_flags}"
         f"-v {mpy_dir}:{mpy_dir} -w {mpy_dir} "
+        f"{git_volume_mount}"
         f"--user {uid}:{gid} "
         f"-e HOME=/tmp "
         f"{build_container} "

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -1,0 +1,74 @@
+"""Tests for ``get_main_git_directory`` — git worktree detection.
+
+The function uses ``git rev-parse --git-common-dir`` to determine whether the
+caller is in a worktree whose common git directory sits outside the working
+tree (and therefore needs an additional bind-mount inside docker).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mpbuild.build import get_main_git_directory
+
+
+def _git(cwd: Path, *args: str) -> None:
+    """Run a git command in ``cwd``, failing the test if it errors.
+
+    ``-c user.name=... -c user.email=...`` is injected so ``git commit`` works
+    on hosts without a global git config, without otherwise touching the
+    environment that ``git init`` / ``git worktree`` need.
+    """
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.com",
+            *args,
+        ],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_returns_none_for_regular_repo(tmp_path: Path) -> None:
+    """In a normal repo (``.git`` inside the working tree) no extra mount
+    is needed, so the function returns ``None``."""
+    _git(tmp_path, "init", "-q")
+    assert get_main_git_directory(tmp_path) is None
+
+
+def test_returns_common_dir_for_worktree(tmp_path: Path) -> None:
+    """In a worktree (where the common .git dir sits outside the working
+    tree) the function returns the absolute path of that common dir."""
+    main_repo = tmp_path / "main"
+    work_tree = tmp_path / "work"
+    main_repo.mkdir()
+    _git(main_repo, "init", "-q")
+    (main_repo / "README").write_text("hello")
+    _git(main_repo, "add", "README")
+    _git(main_repo, "commit", "-q", "-m", "initial")
+    _git(main_repo, "worktree", "add", "-q", str(work_tree))
+
+    result = get_main_git_directory(work_tree)
+
+    assert result is not None
+    # The common dir is the .git inside the main repo, resolved absolutely.
+    assert result == (main_repo / ".git").resolve()
+
+
+def test_raises_when_git_not_found(tmp_path: Path, monkeypatch) -> None:
+    """If git is not on PATH, the helper raises RuntimeError with a hint."""
+
+    def _no_git(*_args, **_kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr("mpbuild.build.subprocess.run", _no_git)
+    with pytest.raises(RuntimeError, match="Git command not found"):
+        get_main_git_directory(tmp_path)


### PR DESCRIPTION
## Summary
- Adds support for building MicroPython from git worktrees
- Detects when `.git` is a file (worktree) vs directory (regular repo)
- Mounts the main `.git` directory in Docker container for worktree builds

## Problem
When building from a git worktree, mpbuild fails with error:
```
fatal: not a git repository: /path/to/.git/worktrees/name
make: *** [../../py/mkrules.mk:269: submodules] Error 128
```

## Solution
The Docker container now properly mounts the main `.git` directory (e.g., `/home/user/repo/.git`) instead of the worktree-specific path (e.g., `/home/user/repo/.git/worktrees/name`), giving the container access to the full git repository data needed for submodule updates and version calculations.

## Test plan
- [x] Test with regular git repository (no regression)
- [x] Test with git worktree setup
- [x] Verify Docker command includes proper volume mount

🤖 Generated with [Claude Code](https://claude.ai/code)