### PR TITLE
Update idf_v5.4.1 to 5.4.2

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -23,7 +23,7 @@ BUILD_CONTAINERS = {
     "renesas-ra": ARM_BUILD_CONTAINER,
     "samd": ARM_BUILD_CONTAINER,
     "psoc6": "ifxmakers/mpy-mtb-ci",
-    "esp32": "espressif/idf:v5.4.1",
+    "esp32": "espressif/idf:v5.4.2",
     "esp8266": "larsks/esp-open-sdk",
     "unix": "gcc:12-bookworm",  # Special, doesn't have boards
 }


### PR DESCRIPTION
This commit syncs the idf version with MicroPython.

https://github.com/micropython/micropython/commit/10ef3e4ac2767b68f746f0ebb995672076eee67d.


**Tests**

Successfully build

```
mpbuild build ESP32_GENERIC
mpbuild build ESP32_GENERIC_S3
mpbuild build ESP32_GENERIC_S2
mpbuild build ESP32_GENERIC_C6
```