### PR TITLE
Auto-detect ESP-IDF version for esp32 builds

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 
 from pathlib import Path
 import multiprocessing
+import re
 import subprocess
 import sys
 import glob
@@ -15,6 +16,8 @@ from . import board_database, find_mpy_root
 from .board_database import Board
 
 ARM_BUILD_CONTAINER = "micropython/build-micropython-arm"
+ESP_IDF_CONTAINER = "espressif/idf"
+ESP_IDF_FALLBACK_VERSION = "v5.4.2"
 BUILD_CONTAINERS = {
     "stm32": ARM_BUILD_CONTAINER,
     "rp2": ARM_BUILD_CONTAINER,
@@ -23,10 +26,105 @@ BUILD_CONTAINERS = {
     "renesas-ra": ARM_BUILD_CONTAINER,
     "samd": ARM_BUILD_CONTAINER,
     "psoc6": "ifxmakers/mpy-mtb-ci",
-    "esp32": "espressif/idf:v5.4.2",
+    "esp32": f"{ESP_IDF_CONTAINER}:{ESP_IDF_FALLBACK_VERSION}",
     "esp8266": "larsks/esp-open-sdk",
     "unix": "gcc:12-bookworm",  # Special, doesn't have boards
 }
+
+
+def _detect_idf_version_from_lockfile(mpy_dir: Path, mcu: str) -> str | None:
+    """
+    Detect the ESP-IDF version from the MicroPython lockfiles (tier 1).
+
+    Each ESP32 chip type (esp32, esp32s2, esp32s3, esp32c3, etc.) has its own
+    lockfile at ``ports/esp32/lockfiles/dependencies.lock.<mcu>`` that specifies
+    the exact IDF version used for that target.
+
+    Args:
+        mpy_dir: Path to the MicroPython repository root.
+        mcu: The MCU/chip target name from board.json (e.g., "esp32", "esp32s3").
+
+    Returns:
+        The ESP-IDF version string (e.g., "v5.5.1"), or None if detection fails.
+    """
+    lockfile_path = (
+        mpy_dir / "ports" / "esp32" / "lockfiles" / f"dependencies.lock.{mcu}"
+    )
+    if not lockfile_path.is_file():
+        return None
+
+    try:
+        content = lockfile_path.read_text()
+    except OSError:
+        return None
+
+    # Parse the idf dependency version from the lockfile YAML.
+    # The structure is:
+    #   dependencies:
+    #     idf:
+    #       source:
+    #         type: idf
+    #       version: 5.5.1
+    # Match "idf:" at the top-level dependency indent, then find its "version:" field.
+    match = re.search(
+        r"^  idf:\n(?:    .*\n)*?    version:\s*([\d.]+)", content, re.MULTILINE
+    )
+    if match:
+        return f"v{match.group(1)}"
+
+    return None
+
+
+def _detect_idf_version_from_ci_workflow(mpy_dir: Path) -> str | None:
+    """
+    Detect the recommended ESP-IDF version from the CI workflow file (tier 2).
+
+    Parses ``.github/workflows/ports_esp32.yml`` to find the ``IDF_NEWEST_VER``
+    value, which is the newest supported ESP-IDF version.
+
+    Args:
+        mpy_dir: Path to the MicroPython repository root.
+
+    Returns:
+        The ESP-IDF version string (e.g., "v5.5.1"), or None if detection fails.
+    """
+    workflow_path = mpy_dir / ".github" / "workflows" / "ports_esp32.yml"
+    if not workflow_path.is_file():
+        return None
+
+    try:
+        content = workflow_path.read_text()
+    except OSError:
+        return None
+
+    # Match the IDF_NEWEST_VER env variable in the workflow YAML
+    # e.g.: IDF_NEWEST_VER: &newest "v5.5.1"
+    # or:   IDF_NEWEST_VER: "v5.5.1"
+    match = re.search(r"IDF_NEWEST_VER:\s*(?:&\w+\s+)?([\"']?)(v[\d.]+)\1", content)
+    if match:
+        return match.group(2)
+
+    return None
+
+
+def detect_idf_version(mpy_dir: Path, mcu: str) -> str | None:
+    """
+    Detect the ESP-IDF version using a three-tier fallback strategy:
+
+    1. **Lockfile** — per-chip-type lockfile in ``ports/esp32/lockfiles/``
+    2. **CI workflow** — ``IDF_NEWEST_VER`` from ``.github/workflows/ports_esp32.yml``
+    3. Returns ``None`` so callers can fall back to a hardcoded default.
+
+    Args:
+        mpy_dir: Path to the MicroPython repository root.
+        mcu: The MCU/chip target name from board.json (e.g., "esp32", "esp32s3").
+
+    Returns:
+        The ESP-IDF version string (e.g., "v5.5.1"), or None if all detection fails.
+    """
+    return _detect_idf_version_from_lockfile(
+        mpy_dir, mcu
+    ) or _detect_idf_version_from_ci_workflow(mpy_dir)
 
 
 class MpbuildNotSupportedException(Exception):
@@ -37,8 +135,16 @@ def get_build_container(board: Board, variant: Optional[str] = None) -> str:
     """
     Returns the container to be used for this board/variant.
 
+    For the esp32 port, the ESP-IDF version is auto-detected using a
+    three-tier fallback:
+
+    1. Lockfile (``ports/esp32/lockfiles/dependencies.lock.<mcu>``) — per chip type
+    2. CI workflow (``IDF_NEWEST_VER`` in ``.github/workflows/ports_esp32.yml``)
+    3. Hardcoded fallback version
+
     Example: board="RPI_PICO" => "micropython/build-micropython-arm"
     Example: board="RPI_PICO", variant="RISCV" => "micropython/build-micropython-rp2350riscv"
+    Example: board="ESP32_GENERIC" => "espressif/idf:v5.5.1" (auto-detected)
     """
     port = board.port
 
@@ -50,6 +156,12 @@ def get_build_container(board: Board, variant: Optional[str] = None) -> str:
 
         # RP2 requires a recent version of gcc
         return "micropython/build-micropython-arm:bookworm"
+
+    if port.name == "esp32":
+        idf_version = detect_idf_version(port.directory_repo, board.mcu)
+        if idf_version:
+            return f"{ESP_IDF_CONTAINER}:{idf_version}"
+        return f"{ESP_IDF_CONTAINER}:{ESP_IDF_FALLBACK_VERSION}"
 
     try:
         return BUILD_CONTAINERS[port.name]

--- a/tests/test_detect_idf_version.py
+++ b/tests/test_detect_idf_version.py
@@ -1,0 +1,217 @@
+"""Tests for ESP-IDF version detection (three-tier fallback)."""
+
+from pathlib import Path
+import tempfile
+
+from mpbuild.build import (
+    _detect_idf_version_from_lockfile,
+    _detect_idf_version_from_ci_workflow,
+    detect_idf_version,
+)
+
+# ---------------------------------------------------------------------------
+# Sample lockfile content matching the real MicroPython format
+# ---------------------------------------------------------------------------
+LOCKFILE_ESP32 = """\
+dependencies:
+  espressif/lan867x:
+    component_hash: 0ff9dae3affeff53811e7c8283e67c6d36dc0c03e3bc5102c0fba629e08bf6c4
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.3'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    targets:
+    - esp32
+    - esp32p4
+    version: 1.0.3
+  espressif/mdns:
+    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.1.0
+  idf:
+    source:
+      type: idf
+    version: 5.5.1
+direct_dependencies:
+- espressif/lan867x
+- espressif/mdns
+- idf
+manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+target: esp32
+version: 2.0.0
+"""
+
+LOCKFILE_ESP32S3 = """\
+dependencies:
+  espressif/mdns:
+    version: 1.1.0
+  idf:
+    source:
+      type: idf
+    version: 5.4.2
+direct_dependencies:
+- espressif/mdns
+- idf
+target: esp32s3
+version: 2.0.0
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _write_lockfile(tmp_path: Path, mcu: str, content: str) -> None:
+    lockfile_dir = tmp_path / "ports" / "esp32" / "lockfiles"
+    lockfile_dir.mkdir(parents=True, exist_ok=True)
+    (lockfile_dir / f"dependencies.lock.{mcu}").write_text(content)
+
+
+def _write_workflow(tmp_path: Path, content: str) -> None:
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "ports_esp32.yml").write_text(content)
+
+
+CI_WORKFLOW = (
+    'env:\n  IDF_OLDEST_VER: &oldest "v5.3"\n  IDF_NEWEST_VER: &newest "v5.5.1"\n'
+)
+
+
+# ===================================================================
+# Tier 1 – Lockfile detection
+# ===================================================================
+class TestLockfileDetection:
+    def test_esp32_version(self):
+        """Detects IDF version from the esp32 lockfile."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_lockfile(p, "esp32", LOCKFILE_ESP32)
+            assert _detect_idf_version_from_lockfile(p, "esp32") == "v5.5.1"
+
+    def test_esp32s3_version(self):
+        """Detects IDF version from the esp32s3 lockfile."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_lockfile(p, "esp32s3", LOCKFILE_ESP32S3)
+            assert _detect_idf_version_from_lockfile(p, "esp32s3") == "v5.4.2"
+
+    def test_per_chip_type(self):
+        """Different chip types can report different IDF versions."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_lockfile(p, "esp32", LOCKFILE_ESP32)
+            _write_lockfile(p, "esp32s3", LOCKFILE_ESP32S3)
+            assert _detect_idf_version_from_lockfile(p, "esp32") == "v5.5.1"
+            assert _detect_idf_version_from_lockfile(p, "esp32s3") == "v5.4.2"
+
+    def test_missing_lockfile(self):
+        """Returns None when the lockfile does not exist."""
+        with tempfile.TemporaryDirectory() as tmp:
+            assert _detect_idf_version_from_lockfile(Path(tmp), "esp32") is None
+
+    def test_wrong_mcu(self):
+        """Returns None when lockfile exists for esp32 but not the requested MCU."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_lockfile(p, "esp32", LOCKFILE_ESP32)
+            assert _detect_idf_version_from_lockfile(p, "esp32c6") is None
+
+    def test_no_idf_in_lockfile(self):
+        """Returns None when the lockfile has no idf dependency."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            content = (
+                "dependencies:\n  espressif/mdns:\n    version: 1.1.0\ntarget: esp32\n"
+            )
+            _write_lockfile(p, "esp32", content)
+            assert _detect_idf_version_from_lockfile(p, "esp32") is None
+
+    def test_prepends_v(self):
+        """Lockfile stores '5.5.1'; result must be 'v5.5.1'."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_lockfile(p, "esp32", LOCKFILE_ESP32)
+            result = _detect_idf_version_from_lockfile(p, "esp32")
+            assert result is not None and result.startswith("v")
+
+
+# ===================================================================
+# Tier 2 – CI workflow detection
+# ===================================================================
+class TestCIWorkflowDetection:
+    def test_with_anchor_and_quotes(self):
+        """Standard format: IDF_NEWEST_VER: &newest "v5.5.1" """
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_workflow(p, CI_WORKFLOW)
+            assert _detect_idf_version_from_ci_workflow(p) == "v5.5.1"
+
+    def test_without_anchor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_workflow(p, 'env:\n  IDF_NEWEST_VER: "v5.4.2"\n')
+            assert _detect_idf_version_from_ci_workflow(p) == "v5.4.2"
+
+    def test_single_quotes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_workflow(p, "env:\n  IDF_NEWEST_VER: 'v5.4.1'\n")
+            assert _detect_idf_version_from_ci_workflow(p) == "v5.4.1"
+
+    def test_without_quotes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_workflow(p, "env:\n  IDF_NEWEST_VER: v5.3\n")
+            assert _detect_idf_version_from_ci_workflow(p) == "v5.3"
+
+    def test_missing_workflow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assert _detect_idf_version_from_ci_workflow(Path(tmp)) is None
+
+    def test_no_idf_version_in_workflow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_workflow(p, "name: esp32 port\non:\n  push:\n")
+            assert _detect_idf_version_from_ci_workflow(p) is None
+
+
+# ===================================================================
+# Combined – three-tier fallback (detect_idf_version)
+# ===================================================================
+class TestDetectIdfVersionFallback:
+    def test_lockfile_wins_over_ci(self):
+        """Tier 1 (lockfile) takes priority over tier 2 (CI workflow)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_lockfile(p, "esp32", LOCKFILE_ESP32)  # version 5.5.1
+            _write_workflow(p, 'env:\n  IDF_NEWEST_VER: "v5.3"\n')  # version v5.3
+            assert detect_idf_version(p, "esp32") == "v5.5.1"
+
+    def test_falls_back_to_ci_when_no_lockfile(self):
+        """When lockfile is missing, tier 2 (CI workflow) is used."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_workflow(p, CI_WORKFLOW)
+            assert detect_idf_version(p, "esp32") == "v5.5.1"
+
+    def test_falls_back_to_ci_for_unknown_mcu(self):
+        """Lockfile exists for esp32, but not for esp32c6 → falls back to CI."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)
+            _write_lockfile(p, "esp32", LOCKFILE_ESP32)
+            _write_workflow(p, 'env:\n  IDF_NEWEST_VER: "v5.4.0"\n')
+            assert detect_idf_version(p, "esp32c6") == "v5.4.0"
+
+    def test_returns_none_when_nothing_available(self):
+        """Returns None when neither lockfile nor CI workflow is available."""
+        with tempfile.TemporaryDirectory() as tmp:
+            assert detect_idf_version(Path(tmp), "esp32") is None


### PR DESCRIPTION
Implement a detection mechanism for the ESP-IDF version from the MicroPython source tree, utilizing a three-tier fallback strategy. 

- reading the IDF version from the lockfile
- reading the max IDF version from the CI build workflow
- fallback to a hardcoded version if detection fails.

This simplifies the use of the current correct ESP IDF version when building esp32 projects.


Tested locally and it auto picks the IDF version,
the `--build-container` option can still be used to specify a different IDF version.

I did use AI to create this PR, but I have checked it.