### PR TITLE
Fix ModuleNotFoundError for typing_extensions

### DIFF
--- a/src/mpbuild/cli.py
+++ b/src/mpbuild/cli.py
@@ -1,5 +1,4 @@
-from typing import Optional, List
-from typing_extensions import Annotated
+from typing import Annotated, List, Optional
 
 import typer
 


### PR DESCRIPTION
## Summary
- `src/mpbuild/cli.py` imported `Annotated` from `typing_extensions`, but that package was never declared in `pyproject.toml` dependencies — so a fresh `mpbuild` install fails with `ModuleNotFoundError: No module named 'typing_extensions'`.
- Switched to `from typing import Annotated, ...`. `typing.Annotated` has been in the stdlib since Python 3.9 and the project already requires `>= 3.12`, so no new dependency is needed.

## Test plan
- [x] `mpbuild list` no longer raises `ModuleNotFoundError` (now reaches its real "Please run from MicroPython source tree" check).
- [x] No other usage of `typing_extensions` in the codebase (`grep -rn typing_extensions src/` is empty after the change).