### PR TITLE
Phase 3: tests for build container resolution and docker command assembly

### DIFF
--- a/tests/test_build_container.py
+++ b/tests/test_build_container.py
@@ -1,0 +1,140 @@
+"""Tests for get_build_container — port -> docker image resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from mpbuild.board_database import Board, Database, Port
+from mpbuild.build import (
+    ARM_BUILD_CONTAINER,
+    ESP_IDF_CONTAINER,
+    ESP_IDF_FALLBACK_VERSION,
+    MpbuildNotSupportedException,
+    get_build_container,
+)
+
+
+# Sample lockfile content reused from the IDF detection tests.
+LOCKFILE_ESP32 = """\
+dependencies:
+  idf:
+    source:
+      type: idf
+    version: 5.5.1
+target: esp32
+version: 2.0.0
+"""
+
+
+# ===================================================================
+# Simple ports: direct lookup in BUILD_CONTAINERS
+# ===================================================================
+class TestSimplePorts:
+    @pytest.mark.parametrize(
+        "port_name, expected",
+        [
+            ("stm32", ARM_BUILD_CONTAINER),
+            ("nrf", ARM_BUILD_CONTAINER),
+            ("mimxrt", ARM_BUILD_CONTAINER),
+            ("renesas-ra", ARM_BUILD_CONTAINER),
+            ("samd", ARM_BUILD_CONTAINER),
+            ("psoc6", "ifxmakers/mpy-mtb-ci"),
+            ("esp8266", "larsks/esp-open-sdk"),
+        ],
+    )
+    def test_physical_port_maps_to_container(
+        self, mpy_root, make_board, port_name, expected
+    ):
+        """Each non-special port maps directly to its container in BUILD_CONTAINERS."""
+        make_board(port_name, "BOARD_X", mcu="dummy")
+        db = Database(mpy_root)
+        assert get_build_container(db.boards["BOARD_X"]) == expected
+
+    def test_unix_special_port(self, mpy_root):
+        """The 'unix' special port resolves to its gcc image."""
+        db = Database(mpy_root)
+        assert get_build_container(db.boards["unix"]) == "gcc:12-bookworm"
+
+    def test_unsupported_port_raises(self, mpy_root):
+        """Ports not in BUILD_CONTAINERS raise MpbuildNotSupportedException."""
+        # 'webassembly' is auto-added as a special port but is not in BUILD_CONTAINERS.
+        db = Database(mpy_root)
+        with pytest.raises(MpbuildNotSupportedException, match="webassembly"):
+            get_build_container(db.boards["webassembly"])
+
+
+# ===================================================================
+# rp2 — has its own resolution path (default + RISCV variant)
+# ===================================================================
+class TestRp2:
+    def test_default_returns_arm_bookworm(self, mpy_root, make_board):
+        """rp2 needs a recent gcc; default resolves to the arm:bookworm image."""
+        make_board("rp2", "RPI_PICO", mcu="rp2040")
+        db = Database(mpy_root)
+        assert (
+            get_build_container(db.boards["RPI_PICO"])
+            == "micropython/build-micropython-arm:bookworm"
+        )
+
+    def test_riscv_variant_uses_dedicated_image(self, mpy_root, make_board):
+        """The RISCV variant (rp2350) uses its own dedicated container."""
+        make_board(
+            "rp2", "RPI_PICO2",
+            mcu="rp2350",
+            variants={"RISCV": "RISC-V core"},
+        )
+        db = Database(mpy_root)
+        assert (
+            get_build_container(db.boards["RPI_PICO2"], variant="RISCV")
+            == "micropython/build-micropython-rp2350riscv"
+        )
+
+    def test_non_riscv_variant_uses_default(self, mpy_root, make_board):
+        """Other rp2 variants still get the regular arm:bookworm container."""
+        make_board(
+            "rp2", "WEACTSTUDIO",
+            mcu="rp2040",
+            variants={"FLASH_2M": "2 MB flash"},
+        )
+        db = Database(mpy_root)
+        assert (
+            get_build_container(db.boards["WEACTSTUDIO"], variant="FLASH_2M")
+            == "micropython/build-micropython-arm:bookworm"
+        )
+
+
+# ===================================================================
+# esp32 — IDF version detection drives the container tag
+# ===================================================================
+class TestEsp32:
+    def test_uses_detected_idf_version(self, mpy_root, make_board, make_lockfile):
+        """When a lockfile pins an IDF version, the container tag matches it."""
+        make_board("esp32", "ESP32_GENERIC", mcu="esp32")
+        make_lockfile("esp32", LOCKFILE_ESP32)
+        db = Database(mpy_root)
+        assert (
+            get_build_container(db.boards["ESP32_GENERIC"])
+            == f"{ESP_IDF_CONTAINER}:v5.5.1"
+        )
+
+    def test_falls_back_when_detection_fails(self, mpy_root, make_board):
+        """Without a lockfile or workflow, esp32 uses the hardcoded fallback version."""
+        make_board("esp32", "ESP32_GENERIC", mcu="esp32")
+        db = Database(mpy_root)
+        assert (
+            get_build_container(db.boards["ESP32_GENERIC"])
+            == f"{ESP_IDF_CONTAINER}:{ESP_IDF_FALLBACK_VERSION}"
+        )
+
+    def test_per_chip_idf_version(self, mpy_root, make_board, make_lockfile):
+        """Different chip types pick up the per-MCU lockfile version."""
+        make_board("esp32", "ESP32_GENERIC_S3", mcu="esp32s3")
+        make_lockfile(
+            "esp32s3",
+            "dependencies:\n  idf:\n    source:\n      type: idf\n    version: 5.4.2\n",
+        )
+        db = Database(mpy_root)
+        assert (
+            get_build_container(db.boards["ESP32_GENERIC_S3"])
+            == f"{ESP_IDF_CONTAINER}:v5.4.2"
+        )

--- a/tests/test_docker_build_cmd.py
+++ b/tests/test_docker_build_cmd.py
@@ -1,0 +1,183 @@
+"""Tests for docker_build_cmd — assembling the docker run invocation."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from mpbuild.board_database import Database
+from mpbuild.build import docker_build_cmd
+
+
+@pytest.fixture(autouse=True)
+def _stub_host_devices(monkeypatch):
+    """Make device discovery deterministic so tests don't depend on the host.
+
+    docker_build_cmd inspects /dev/bus/usb/ and globs /dev/ttyACM* / ttyUSB*
+    to populate ``--device`` flags. Stubbing these to empty makes the produced
+    command stable across machines.
+    """
+    monkeypatch.setattr("mpbuild.build.glob.glob", lambda _pattern: [])
+    monkeypatch.setattr("mpbuild.build.os.path.exists", lambda _p: False)
+
+
+# ===================================================================
+# Basic shape — non-clean, no variant, simple port
+# ===================================================================
+class TestDockerBuildCmdBasics:
+    def test_shape(self, mpy_root, make_board):
+        """The build command runs docker, mounts the mpy dir, and runs make under bash."""
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(db.boards["PYBV11"])
+
+        assert cmd.startswith("docker run --rm ")
+        assert f"-v {mpy_root}:{mpy_root} -w {mpy_root}" in cmd
+        assert "micropython/build-micropython-arm" in cmd
+        assert "bash -c " in cmd
+        assert "make -C mpy-cross && " in cmd
+        assert "make -C ports/stm32 BOARD=PYBV11 submodules && " in cmd
+        assert "make -j" in cmd
+        assert "ports/stm32 BOARD=PYBV11" in cmd
+
+    def test_uses_running_user_id(self, mpy_root, make_board):
+        """A non-clean build runs as the host user so artefact ownership matches."""
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(db.boards["PYBV11"])
+        assert f"--user {os.getuid()}:{os.getgid()} " in cmd
+
+    def test_interactive_default(self, mpy_root, make_board):
+        """docker_interactive=True (default in tests here) adds the -it flag."""
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(db.boards["PYBV11"], docker_interactive=True)
+        assert " -it " in cmd
+
+    def test_non_interactive_omits_it_flag(self, mpy_root, make_board):
+        """docker_interactive=False omits the -it flag (e.g. when stdin is not a TTY)."""
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(db.boards["PYBV11"], docker_interactive=False)
+        assert " -it " not in cmd
+
+
+# ===================================================================
+# Variants
+# ===================================================================
+class TestDockerBuildCmdVariants:
+    def test_physical_board_uses_BOARD_VARIANT(self, mpy_root, make_board):
+        """Physical boards pass the variant via BOARD_VARIANT=."""
+        make_board(
+            "stm32", "PYBV11",
+            mcu="stm32f4",
+            variants={"DP_THREAD": "Double precision + Threads"},
+        )
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(db.boards["PYBV11"], variant="DP_THREAD")
+        assert "BOARD=PYBV11 BOARD_VARIANT=DP_THREAD" in cmd
+        assert "VARIANT=DP_THREAD" not in cmd or "BOARD_VARIANT=DP_THREAD" in cmd
+
+    def test_special_port_uses_VARIANT(self, mpy_root):
+        """Special ports (physical_board=False) use VARIANT= instead of BOARD_VARIANT=."""
+        # 'unix' is a special port; give it a 'standard' variant subdir.
+        unix_variants = mpy_root / "ports" / "unix" / "variants"
+        unix_variants.mkdir(parents=True)
+        (unix_variants / "standard").mkdir()
+
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(db.boards["unix"], variant="standard")
+        assert "BOARD=unix VARIANT=standard" in cmd
+        assert "BOARD_VARIANT=standard" not in cmd
+
+    def test_unknown_variant_raises(self, mpy_root, make_board):
+        """An unknown variant for the board raises ValueError."""
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        with pytest.raises(ValueError, match="Variant 'NOPE' not found"):
+            docker_build_cmd(db.boards["PYBV11"], variant="NOPE")
+
+
+# ===================================================================
+# Clean
+# ===================================================================
+class TestDockerBuildCmdClean:
+    def test_clean_runs_as_root(self, mpy_root, make_board):
+        """do_clean=True runs as root (uid=0, gid=0) for permission to remove files."""
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(db.boards["PYBV11"], do_clean=True)
+        assert "--user 0:0 " in cmd
+        assert f"--user {os.getuid()}:{os.getgid()} " not in cmd
+
+    def test_clean_skips_mpy_cross_and_submodules(self, mpy_root, make_board):
+        """do_clean=True skips the mpy-cross build and submodule update steps."""
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(db.boards["PYBV11"], do_clean=True)
+        assert "make -C mpy-cross" not in cmd
+        assert "submodules" not in cmd
+
+
+# ===================================================================
+# Container override
+# ===================================================================
+class TestDockerBuildCmdContainerOverride:
+    def test_override_bypasses_port_lookup(self, mpy_root, make_board):
+        """build_container_override is used verbatim, replacing the port-derived image."""
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(
+            db.boards["PYBV11"],
+            build_container_override="custom/image:tag",
+        )
+        assert "custom/image:tag" in cmd
+        assert "micropython/build-micropython-arm" not in cmd
+
+
+# ===================================================================
+# extra_args
+# ===================================================================
+class TestDockerBuildCmdExtraArgs:
+    def test_extra_args_appended_to_make(self, mpy_root, make_board):
+        """extra_args are space-joined and appended after the make target."""
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(
+            db.boards["PYBV11"],
+            extra_args=["V=1", "DEBUG=1"],
+        )
+        assert " V=1 DEBUG=1" in cmd
+
+
+# ===================================================================
+# Device flags (with the autouse stub overridden)
+# ===================================================================
+class TestDockerBuildCmdDeviceFlags:
+    def test_includes_tty_devices_when_present(self, mpy_root, make_board, monkeypatch):
+        """Discovered tty devices are passed through as --device flags."""
+        def fake_glob(pattern):
+            if "ttyACM" in pattern:
+                return ["/dev/ttyACM0"]
+            if "ttyUSB" in pattern:
+                return ["/dev/ttyUSB0"]
+            return []
+
+        monkeypatch.setattr("mpbuild.build.glob.glob", fake_glob)
+
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(db.boards["PYBV11"])
+        assert "--device /dev/ttyACM0" in cmd
+        assert "--device /dev/ttyUSB0" in cmd
+
+    def test_includes_usb_bus_when_populated(self, mpy_root, make_board, monkeypatch):
+        """When /dev/bus/usb/ exists and is non-empty, it's passed as a --device."""
+        monkeypatch.setattr("mpbuild.build.os.path.exists", lambda p: p == "/dev/bus/usb/")
+        monkeypatch.setattr("mpbuild.build.os.listdir", lambda p: ["001"])
+
+        make_board("stm32", "PYBV11", mcu="stm32f4")
+        db = Database(mpy_root)
+        cmd = docker_build_cmd(db.boards["PYBV11"])
+        assert "--device /dev/bus/usb/" in cmd


### PR DESCRIPTION
## Summary

Third PR in the test-coverage series (Phases 1 and 2 = #97 and #98). Covers the pure string-building portion of `build.py` — everything up to `build_board()`/`clean_board()`, which actually spawn a docker subprocess and remain deferred per the pragmatic-coverage decision.

**New files**

`tests/test_build_container.py` (15 tests):
- `TestSimplePorts` — parametrised over each non-special port (`stm32`, `nrf`, `mimxrt`, `renesas-ra`, `samd`, `psoc6`, `esp8266`), the `unix` special port, and `MpbuildNotSupportedException` for ports outside `BUILD_CONTAINERS` (e.g. `webassembly`).
- `TestRp2` — default `arm:bookworm`, dedicated `rp2350riscv` for `variant=RISCV`, regular image for other variants.
- `TestEsp32` — container tag matches the IDF version detected from a lockfile; `ESP_IDF_FALLBACK_VERSION` when nothing is detected; per-chip lockfile selection.

`tests/test_docker_build_cmd.py` (13 tests):
- `TestDockerBuildCmdBasics` — shape (`docker run`, mpy mount, `bash -c`, `make` targets); host uid/gid in `--user`; `-it` flag toggled by `docker_interactive`.
- `TestDockerBuildCmdVariants` — `BOARD_VARIANT=` for physical boards, `VARIANT=` for special ports, `ValueError` for unknown variants.
- `TestDockerBuildCmdClean` — `--user 0:0`, no mpy-cross, no submodules.
- `TestDockerBuildCmdContainerOverride` — override bypasses port-derived image entirely.
- `TestDockerBuildCmdExtraArgs` — `extra_args` appended after the make target.
- `TestDockerBuildCmdDeviceFlags` — `--device` flags for `/dev/tty*` and `/dev/bus/usb/`.

An autouse fixture in `test_docker_build_cmd.py` stubs `glob.glob` and `os.path.exists` so device discovery is deterministic across hosts; the device-flag tests override the stub.

## Coverage

| Module | Phase 2 | After Phase 3 |
|---|---|---|
| `build.py` | 38% | **72%** |
| Total project | 49% | **59%** |

Remaining `build.py` gap (lines 266–316, 324): `build_board()` / `clean_board()` — the docker subprocess paths, deliberately deferred. A handful of `OSError` branches in IDF detection (lines 58–59, 97–98) are also skipped as low-value error paths.

## Test plan
- [x] `uv run pytest -v` — 85 passed (17 IDF + 40 data layer + 28 build logic).
- [x] `uv run pytest --cov=mpbuild --cov-report=term-missing` — confirms `build.py` jump.
- [x] No host-dependent flakiness: tests pass with no USB devices on this WSL machine.