### PR TITLE
Modernise ruff: config, fix codebase, gate via CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,23 @@ jobs:
 
       - name: Run tests
         run: uv run pytest --cov=mpbuild --cov-report=term-missing
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dev dependencies
+        run: uv sync --group dev
+
+      - name: Ruff lint
+        run: uv run ruff check
+
+      - name: Ruff format check
+        run: uv run ruff format --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,11 +10,11 @@ repos:
     -   id: check-added-large-files
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.6.1
+  # Ruff version. Keep in sync with the ruff entry in pyproject.toml's dev group.
+  rev: v0.15.12
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "pre-commit>=4.0.1",
     "pytest>=8",
     "pytest-cov>=5",
+    "ruff>=0.13",
 ]
 
 [tool.pytest.ini_options]
@@ -44,3 +45,10 @@ addopts = "-ra"
 [tool.coverage.run]
 source = ["src/mpbuild"]
 omit = ["src/mpbuild/__main__.py"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]

--- a/src/mpbuild/__init__.py
+++ b/src/mpbuild/__init__.py
@@ -1,11 +1,12 @@
 __app_name__ = "mpbuild"
 __version__ = "0.1.0"
 
-from enum import Enum
+from enum import StrEnum
 from functools import cache
 from pathlib import Path
-from .find_boards import find_mpy_root
+
 from .board_database import Database
+from .find_boards import find_mpy_root
 
 
 @cache
@@ -16,6 +17,6 @@ def board_database(mpy_dir: Path | None = None, port: str | None = None) -> Data
     return Database(mpy_dir, port)
 
 
-class OutputFormat(str, Enum):
+class OutputFormat(StrEnum):
     rich = "rich"
     text = "text"

--- a/src/mpbuild/__main__.py
+++ b/src/mpbuild/__main__.py
@@ -1,4 +1,4 @@
-from . import cli, __app_name__
+from . import __app_name__, cli
 
 
 def main():

--- a/src/mpbuild/board_database.py
+++ b/src/mpbuild/board_database.py
@@ -120,12 +120,7 @@ class Board:
             port=port,
         )
         board.variants.extend(
-            sorted(
-                [
-                    Variant(*v, board=board)
-                    for v in board_json.get("variants", {}).items()
-                ]
-            )
+            sorted([Variant(*v, board=board) for v in board_json.get("variants", {}).items()])
         )
         return board
 
@@ -160,7 +155,8 @@ class Board:
             if v.name == variant:
                 return v
         print(
-            f"Variant '{variant}' not found for board '{self.name}': Valid variants are: {[v.name for v in self.variants]}"
+            f"Variant '{variant}' not found for board '{self.name}': "
+            f"Valid variants are: {[v.name for v in self.variants]}"
         )
 
         return None
@@ -207,7 +203,8 @@ class Database:
     def __post_init__(self) -> None:
         if not (self.mpy_root_directory / "ports").is_dir():
             raise ValueError(
-                f"'mpy_root_directory' should point to the top of a MicroPython repo: {self.mpy_root_directory}"
+                "'mpy_root_directory' should point to the top of a MicroPython "
+                f"repo: {self.mpy_root_directory}"
             )
 
         # Take care to avoid using Path.glob! Performance was 15x slower.
@@ -236,9 +233,7 @@ class Database:
             if self.port_filter and self.port_filter != special_port_name:
                 continue
             path = self.mpy_root_directory / "ports" / special_port_name
-            variant_names = [
-                var.name for var in path.glob("variants/*") if var.is_dir()
-            ]
+            variant_names = [var.name for var in path.glob("variants/*") if var.is_dir()]
             port = Port(
                 name=special_port_name,
                 directory=path,
@@ -256,9 +251,7 @@ class Database:
                 port=port,
             )
             port.boards = {special_port_name: board}
-            board.variants = [
-                Variant(name=v, text="", board=board) for v in variant_names
-            ]
+            board.variants = [Variant(name=v, text="", board=board) for v in variant_names]
             self.ports[special_port_name] = port
             self.boards[board.name] = board
 
@@ -273,9 +266,7 @@ class Database:
             )
 
     @staticmethod
-    def check_board_json(
-        board_json: dict, board_name: str, port_name: str
-    ) -> list[str]:
+    def check_board_json(board_json: dict, board_name: str, port_name: str) -> list[str]:
         """
         Checks a board.json file for missing or invalid keys.
         Returns a list of issues found.

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -1,16 +1,14 @@
-import os
-from typing import Optional, List
-
-from pathlib import Path
+import glob
 import multiprocessing
+import os
 import re
 import subprocess
 import sys
-import glob
+from pathlib import Path
 
 from rich import print
-from rich.panel import Panel
 from rich.markdown import Markdown
+from rich.panel import Panel
 
 from . import board_database, find_mpy_root
 from .board_database import Board
@@ -47,9 +45,7 @@ def _detect_idf_version_from_lockfile(mpy_dir: Path, mcu: str) -> str | None:
     Returns:
         The ESP-IDF version string (e.g., "v5.5.1"), or None if detection fails.
     """
-    lockfile_path = (
-        mpy_dir / "ports" / "esp32" / "lockfiles" / f"dependencies.lock.{mcu}"
-    )
+    lockfile_path = mpy_dir / "ports" / "esp32" / "lockfiles" / f"dependencies.lock.{mcu}"
     if not lockfile_path.is_file():
         return None
 
@@ -66,9 +62,7 @@ def _detect_idf_version_from_lockfile(mpy_dir: Path, mcu: str) -> str | None:
     #         type: idf
     #       version: 5.5.1
     # Match "idf:" at the top-level dependency indent, then find its "version:" field.
-    match = re.search(
-        r"^  idf:\n(?:    .*\n)*?    version:\s*([\d.]+)", content, re.MULTILINE
-    )
+    match = re.search(r"^  idf:\n(?:    .*\n)*?    version:\s*([\d.]+)", content, re.MULTILINE)
     if match:
         return f"v{match.group(1)}"
 
@@ -122,16 +116,16 @@ def detect_idf_version(mpy_dir: Path, mcu: str) -> str | None:
     Returns:
         The ESP-IDF version string (e.g., "v5.5.1"), or None if all detection fails.
     """
-    return _detect_idf_version_from_lockfile(
-        mpy_dir, mcu
-    ) or _detect_idf_version_from_ci_workflow(mpy_dir)
+    return _detect_idf_version_from_lockfile(mpy_dir, mcu) or _detect_idf_version_from_ci_workflow(
+        mpy_dir
+    )
 
 
 class MpbuildNotSupportedException(Exception):
     pass
 
 
-def get_build_container(board: Board, variant: Optional[str] = None) -> str:
+def get_build_container(board: Board, variant: str | None = None) -> str:
     """
     Returns the container to be used for this board/variant.
 
@@ -174,8 +168,8 @@ nprocs = multiprocessing.cpu_count()
 
 def docker_build_cmd(
     board: Board,
-    variant: Optional[str] = None,
-    extra_args: List[str] = [],
+    variant: str | None = None,
+    extra_args: list[str] | None = None,
     do_clean: bool = False,
     build_container_override: str | None = None,
     docker_interactive: bool = True,
@@ -183,6 +177,8 @@ def docker_build_cmd(
     """
     Returns the docker-command which will build the firmware.
     """
+    if extra_args is None:
+        extra_args = []
 
     port = board.port
 
@@ -190,7 +186,8 @@ def docker_build_cmd(
         v = board.find_variant(variant)
         if not v:
             raise ValueError(
-                f"Variant '{variant}' not found for board '{board.name}': Valid variants are: {[v.name for v in board.variants]}"
+                f"Variant '{variant}' not found for board '{board.name}': "
+                f"Valid variants are: {[v.name for v in board.variants]}"
             )
 
     build_container = (
@@ -231,31 +228,34 @@ def docker_build_cmd(
     for device in tty_devices:
         device_flags += f"--device {device} "
 
-    # fmt: off
+    # Build the docker run invocation. Each option, in order:
+    #   {device_flags}             USB and serial devices for deploy
+    #   -v <mpy>:<mpy> -w <mpy>    mount mpy dir at same path so elf/map paths match host
+    #   --user <uid>:<gid>         match host user id so generated files aren't owned by root
+    #   -e HOME=/tmp               set HOME to /tmp for the container
     build_cmd = (
         f"docker run --rm "
         f"{'-it ' if docker_interactive else ''}"
-        f"{device_flags}"                       # provides access to USB and serial devices for deploy
-        f"-v {mpy_dir}:{mpy_dir} -w {mpy_dir} " # mount micropython dir with same path so elf/map paths match host
-        f"--user {uid}:{gid} "                  # match running user id so generated files aren't owned by root
-        f"-e HOME=/tmp "                        # set HOME to /tmp for container
+        f"{device_flags}"
+        f"-v {mpy_dir}:{mpy_dir} -w {mpy_dir} "
+        f"--user {uid}:{gid} "
+        f"-e HOME=/tmp "
         f"{build_container} "
         f'bash -c "'
         f"git config --global --add safe.directory '*' 2> /dev/null;"
-        f'{make_mpy_cross_cmd}'
-        f'{update_submodules_cmd}'
+        f"{make_mpy_cross_cmd}"
+        f"{update_submodules_cmd}"
         f'make -j {nprocs} -C ports/{port.name} BOARD={board.name}{variant_cmd}{args}"'
     )
-    # fmt: on
 
     return build_cmd
 
 
 def build_board(
     board: str,
-    variant: Optional[str] = None,
-    extra_args: List[str] = [],
-    build_container_override: Optional[str] = None,
+    variant: str | None = None,
+    extra_args: list[str] | None = None,
+    build_container_override: str | None = None,
     mpy_dir: str | Path | None = None,
 ) -> None:
     """
@@ -263,6 +263,8 @@ def build_board(
 
     This command writes to stdout/stderr and may exit the program on failure.
     """
+    if extra_args is None:
+        extra_args = []
     mpy_dir, _ = find_mpy_root(mpy_dir)
     db = board_database(mpy_dir)
     mpy_dir = db.mpy_root_directory
@@ -318,8 +320,8 @@ def build_board(
 
 def clean_board(
     board: str,
-    variant: Optional[str] = None,
-    mpy_dir: Optional[str] = None,
+    variant: str | None = None,
+    mpy_dir: str | None = None,
 ) -> None:
     build_board(
         board=board,

--- a/src/mpbuild/check_images.py
+++ b/src/mpbuild/check_images.py
@@ -1,13 +1,13 @@
-from . import board_database
 import json
-
-from urllib.request import Request, urlopen
 from urllib.error import HTTPError
+from urllib.request import Request, urlopen
 
-from rich.progress import Progress
 from rich import print
 from rich.panel import Panel
+from rich.progress import Progress
 from rich.table import Table
+
+from . import board_database
 
 
 def check_boards(verbose: bool = False, mpy_dir: str = None) -> None:
@@ -20,9 +20,7 @@ def check_boards(verbose: bool = False, mpy_dir: str = None) -> None:
     image_too_large = []
     board_json_issues = []
 
-    base_url = (
-        r"https://raw.githubusercontent.com/micropython/micropython-media/main/boards"
-    )
+    base_url = r"https://raw.githubusercontent.com/micropython/micropython-media/main/boards"
 
     with Progress(transient=True) as progress:
         task1 = progress.add_task("[cyan]Checking boards...", total=num_boards)
@@ -37,11 +35,9 @@ def check_boards(verbose: bool = False, mpy_dir: str = None) -> None:
                         with open(json_path) as f:
                             board_json = json.load(f)
                             # Check for issues in board.json
-                            issues = db.check_board_json(
-                                board_json, _board.name, _board.port.name
-                            )
+                            issues = db.check_board_json(board_json, _board.name, _board.port.name)
                             board_json_issues.extend(issues)
-                except (json.JSONDecodeError, IOError) as e:
+                except (OSError, json.JSONDecodeError) as e:
                     board_json_issues.append(
                         f"{_board.port.name}/{_board.name}: Error reading board.json: {str(e)}"
                     )
@@ -84,20 +80,14 @@ def check_boards(verbose: bool = False, mpy_dir: str = None) -> None:
         ),
         Panel(
             "\n".join(
-                [
-                    f"[link={url}]{p}/[bright_white]{b}[/][/link]"
-                    for p, b, url in image_not_found
-                ]
+                [f"[link={url}]{p}/[bright_white]{b}[/][/link]" for p, b, url in image_not_found]
             ),
             title="Not found",
             subtitle="Image not in micropython-media",
         ),
         Panel(
             "\n".join(
-                [
-                    f"[link={url}]{p}/[bright_white]{b}[/][/link]"
-                    for p, b, url, s in image_too_large
-                ]
+                [f"[link={url}]{p}/[bright_white]{b}[/][/link]" for p, b, url, s in image_too_large]
             ),
             title="Too large",
             subtitle="Image > 500KB",

--- a/src/mpbuild/cli.py
+++ b/src/mpbuild/cli.py
@@ -1,12 +1,12 @@
-from typing import Annotated, List, Optional
+from typing import Annotated
 
 import typer
 
-from . import __app_name__, __version__, OutputFormat
+from . import OutputFormat, __app_name__, __version__
 from .build import build_board, clean_board
-from .list_boards import print_boards
 from .check_images import check_boards
-from .completions import list_ports, list_boards, list_variants_for_board
+from .completions import list_boards, list_ports, list_variants_for_board
+from .list_boards import print_boards
 
 app = typer.Typer(chain=True, context_settings={"help_option_names": ["-h", "--help"]})
 
@@ -34,18 +34,16 @@ def _complete_port(incomplete: str):
 
 @app.command()
 def build(
-    board: Annotated[
-        str, typer.Argument(help="Board name", autocompletion=_complete_board)
-    ],
+    board: Annotated[str, typer.Argument(help="Board name", autocompletion=_complete_board)],
     variant: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(help="Board variant", autocompletion=_complete_variant),
     ] = None,
     extra_args: Annotated[
-        Optional[List[str]], typer.Argument(help="additional arguments to pass to make")
+        list[str] | None, typer.Argument(help="additional arguments to pass to make")
     ] = None,
     build_container: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Override the default build container"),
     ] = None,
 ) -> None:
@@ -58,9 +56,7 @@ def build(
 
 
 @app.command()
-def clean(
-    board: str, variant: Annotated[Optional[str], typer.Argument()] = None
-) -> None:
+def clean(board: str, variant: Annotated[str | None, typer.Argument()] = None) -> None:
     """
     Clean a MicroPython board.
     """
@@ -70,13 +66,11 @@ def clean(
 @app.command("list")
 def list_boards_and_variants(
     port: Annotated[
-        Optional[str], typer.Argument(help="Port name", autocompletion=_complete_port)
+        str | None, typer.Argument(help="Port name", autocompletion=_complete_port)
     ] = None,
     fmt: Annotated[
         OutputFormat,
-        typer.Option(
-            "--format", case_sensitive=False, help="Configure the output format"
-        ),
+        typer.Option("--format", case_sensitive=False, help="Configure the output format"),
     ] = OutputFormat.rich,
 ) -> None:
     """
@@ -115,7 +109,7 @@ def _version_callback(value: bool) -> None:
 
 @app.callback()
 def main(
-    version: Optional[bool] = typer.Option(
+    version: bool | None = typer.Option(
         None,
         "--version",
         "-v",

--- a/src/mpbuild/find_boards.py
+++ b/src/mpbuild/find_boards.py
@@ -1,10 +1,10 @@
 import os
-from pathlib import Path
 from functools import cache
+from pathlib import Path
 
 
 @cache
-def find_mpy_root(root: str| Path | None = None) -> tuple[Path, str]:
+def find_mpy_root(root: str | Path | None = None) -> tuple[Path, str]:
     if root is None:
         root = Path(os.environ.get("MICROPY_DIR", ".")).resolve()
     else:

--- a/src/mpbuild/list_boards.py
+++ b/src/mpbuild/list_boards.py
@@ -1,13 +1,13 @@
-from typing import Optional
-from . import board_database, OutputFormat
-from rich.tree import Tree
 from rich import print
+from rich.tree import Tree
+
+from . import OutputFormat, board_database
 
 
 def print_boards(
-    port: Optional[str] = None,
+    port: str | None = None,
     fmt: OutputFormat = OutputFormat.rich,
-    mpy_dir: Optional[str] = None,
+    mpy_dir: str | None = None,
 ) -> None:
     db = board_database(mpy_dir, port)
 
@@ -16,16 +16,13 @@ def print_boards(
 
     if fmt == OutputFormat.rich:
         tree = Tree(":snake: [bright_white]MicroPython Boards[/]")
-        tree.add
         for p in sorted(db.ports.values()):
             if not port or (port and port == p.name):
                 treep = tree.add(f"{p.name}   [bright_black]{len(p.boards)}[/]")
                 for b in sorted(p.boards.values()):
                     variants = ", ".join([v.name for v in b.variants])
                     variants = f" [bright_black]{variants}[/]" if variants else ""
-                    treep.add(
-                        f"[bright_white][link={b.url}]{b.name}[/link][/] {variants}"
-                    )
+                    treep.add(f"[bright_white][link={b.url}]{b.name}[/link][/] {variants}")
         print(tree)
 
     if fmt == OutputFormat.text:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,8 @@ they need in their parameter list; pytest wires them up automatically.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import pytest
 

--- a/tests/test_board_database.py
+++ b/tests/test_board_database.py
@@ -256,8 +256,16 @@ class TestBoardProperties:
         """A board pointing at a non-existent dir raises ValueError."""
         port = Port(name="stm32", directory=mpy_root / "ports" / "stm32")
         board = Board(
-            name="GHOST", variants=[], url="", mcu="", product="", vendor="",
-            images=[], deploy=[], physical_board=True, port=port,
+            name="GHOST",
+            variants=[],
+            url="",
+            mcu="",
+            product="",
+            vendor="",
+            images=[],
+            deploy=[],
+            physical_board=True,
+            port=port,
         )
         with pytest.raises(ValueError, match="Directory does not exist"):
             _ = board.directory
@@ -278,7 +286,9 @@ class TestBoardProperties:
     def test_find_variant_hit(self, mpy_root, make_board):
         """find_variant returns the matching Variant."""
         make_board(
-            "stm32", "PYBV11", mcu="stm32f4",
+            "stm32",
+            "PYBV11",
+            mcu="stm32f4",
             variants={"DP": "Double-precision float", "THREAD": "Threading"},
         )
         db = Database(mpy_root)

--- a/tests/test_build_container.py
+++ b/tests/test_build_container.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from mpbuild.board_database import Board, Database, Port
+from mpbuild.board_database import Database
 from mpbuild.build import (
     ARM_BUILD_CONTAINER,
     ESP_IDF_CONTAINER,
@@ -12,7 +12,6 @@ from mpbuild.build import (
     MpbuildNotSupportedException,
     get_build_container,
 )
-
 
 # Sample lockfile content reused from the IDF detection tests.
 LOCKFILE_ESP32 = """\
@@ -42,9 +41,7 @@ class TestSimplePorts:
             ("esp8266", "larsks/esp-open-sdk"),
         ],
     )
-    def test_physical_port_maps_to_container(
-        self, mpy_root, make_board, port_name, expected
-    ):
+    def test_physical_port_maps_to_container(self, mpy_root, make_board, port_name, expected):
         """Each non-special port maps directly to its container in BUILD_CONTAINERS."""
         make_board(port_name, "BOARD_X", mcu="dummy")
         db = Database(mpy_root)
@@ -79,7 +76,8 @@ class TestRp2:
     def test_riscv_variant_uses_dedicated_image(self, mpy_root, make_board):
         """The RISCV variant (rp2350) uses its own dedicated container."""
         make_board(
-            "rp2", "RPI_PICO2",
+            "rp2",
+            "RPI_PICO2",
             mcu="rp2350",
             variants={"RISCV": "RISC-V core"},
         )
@@ -92,7 +90,8 @@ class TestRp2:
     def test_non_riscv_variant_uses_default(self, mpy_root, make_board):
         """Other rp2 variants still get the regular arm:bookworm container."""
         make_board(
-            "rp2", "WEACTSTUDIO",
+            "rp2",
+            "WEACTSTUDIO",
             mcu="rp2040",
             variants={"FLASH_2M": "2 MB flash"},
         )
@@ -112,10 +111,7 @@ class TestEsp32:
         make_board("esp32", "ESP32_GENERIC", mcu="esp32")
         make_lockfile("esp32", LOCKFILE_ESP32)
         db = Database(mpy_root)
-        assert (
-            get_build_container(db.boards["ESP32_GENERIC"])
-            == f"{ESP_IDF_CONTAINER}:v5.5.1"
-        )
+        assert get_build_container(db.boards["ESP32_GENERIC"]) == f"{ESP_IDF_CONTAINER}:v5.5.1"
 
     def test_falls_back_when_detection_fails(self, mpy_root, make_board):
         """Without a lockfile or workflow, esp32 uses the hardcoded fallback version."""
@@ -134,7 +130,4 @@ class TestEsp32:
             "dependencies:\n  idf:\n    source:\n      type: idf\n    version: 5.4.2\n",
         )
         db = Database(mpy_root)
-        assert (
-            get_build_container(db.boards["ESP32_GENERIC_S3"])
-            == f"{ESP_IDF_CONTAINER}:v5.4.2"
-        )
+        assert get_build_container(db.boards["ESP32_GENERIC_S3"]) == f"{ESP_IDF_CONTAINER}:v5.4.2"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,8 +46,10 @@ class TestBuild:
 
         def fake(board, variant, extra_args, build_container):
             called.update(
-                board=board, variant=variant,
-                extra_args=extra_args, build_container=build_container,
+                board=board,
+                variant=variant,
+                extra_args=extra_args,
+                build_container=build_container,
             )
 
         monkeypatch.setattr("mpbuild.cli.build_board", fake)
@@ -96,9 +98,7 @@ class TestBuild:
             "mpbuild.cli.build_board",
             lambda b, v, e, c: called.update(c=c),
         )
-        result = runner.invoke(
-            app, ["build", "--build-container", "custom/image:tag", "PYBV11"]
-        )
+        result = runner.invoke(app, ["build", "--build-container", "custom/image:tag", "PYBV11"])
         assert result.exit_code == 0
         assert called["c"] == "custom/image:tag"
 

--- a/tests/test_detect_idf_version.py
+++ b/tests/test_detect_idf_version.py
@@ -1,8 +1,8 @@
 """Tests for ESP-IDF version detection (three-tier fallback)."""
 
 from mpbuild.build import (
-    _detect_idf_version_from_lockfile,
     _detect_idf_version_from_ci_workflow,
+    _detect_idf_version_from_lockfile,
     detect_idf_version,
 )
 
@@ -62,9 +62,7 @@ target: esp32s3
 version: 2.0.0
 """
 
-CI_WORKFLOW = (
-    'env:\n  IDF_OLDEST_VER: &oldest "v5.3"\n  IDF_NEWEST_VER: &newest "v5.5.1"\n'
-)
+CI_WORKFLOW = 'env:\n  IDF_OLDEST_VER: &oldest "v5.3"\n  IDF_NEWEST_VER: &newest "v5.5.1"\n'
 
 
 # ===================================================================
@@ -156,9 +154,7 @@ class TestDetectIdfVersionFallback:
         make_workflow(CI_WORKFLOW)
         assert detect_idf_version(mpy_root, "esp32") == "v5.5.1"
 
-    def test_falls_back_to_ci_for_unknown_mcu(
-        self, mpy_root, make_lockfile, make_workflow
-    ):
+    def test_falls_back_to_ci_for_unknown_mcu(self, mpy_root, make_lockfile, make_workflow):
         """Lockfile exists for esp32, but not for esp32c6 → falls back to CI."""
         make_lockfile("esp32", LOCKFILE_ESP32)
         make_workflow('env:\n  IDF_NEWEST_VER: "v5.4.0"\n')

--- a/tests/test_docker_build_cmd.py
+++ b/tests/test_docker_build_cmd.py
@@ -70,7 +70,8 @@ class TestDockerBuildCmdVariants:
     def test_physical_board_uses_BOARD_VARIANT(self, mpy_root, make_board):
         """Physical boards pass the variant via BOARD_VARIANT=."""
         make_board(
-            "stm32", "PYBV11",
+            "stm32",
+            "PYBV11",
             mcu="stm32f4",
             variants={"DP_THREAD": "Double precision + Threads"},
         )
@@ -157,6 +158,7 @@ class TestDockerBuildCmdExtraArgs:
 class TestDockerBuildCmdDeviceFlags:
     def test_includes_tty_devices_when_present(self, mpy_root, make_board, monkeypatch):
         """Discovered tty devices are passed through as --device flags."""
+
         def fake_glob(pattern):
             if "ttyACM" in pattern:
                 return ["/dev/ttyACM0"]

--- a/uv.lock
+++ b/uv.lock
@@ -187,6 +187,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -200,6 +201,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-cov", specifier = ">=5" },
+    { name = "ruff", specifier = ">=0.13" },
 ]
 
 [[package]]
@@ -330,6 +332,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase A of the ruff + ty initiative. Modernises the ruff setup end-to-end:

- **Config**: adds `[tool.ruff]` and `[tool.ruff.lint]` to `pyproject.toml` (targeting py312, line-length=100, rule selection `E, F, I, UP, B`).
- **Dev tooling**: adds `ruff>=0.13` to the `dev` dependency group so contributors can invoke it directly via `uv run ruff …` rather than only through pre-commit.
- **Pre-commit**: bumps `astral-sh/ruff-pre-commit` v0.6.1 (Aug 2024) → **v0.15.12**, renames the linter hook id `ruff` → `ruff-check` (canonical in modern revs — the old id now warns "legacy alias"), and bumps `pre-commit/pre-commit-hooks` v3.2.0 → v5.0.0 (silences a deprecation warning).
- **CI**: adds a parallel `lint` job to `test.yml` running `uv run ruff check` and `uv run ruff format --check` as separate steps so a lint failure and a format failure are distinguishable.

## Source-code changes from running ruff

ruff initially reported **42 errors**; **30 were auto-fixed** (`ruff check --fix` + `ruff format`); the remaining 10 were resolved manually:

- **`OutputFormat(StrEnum)`** — replaces `class OutputFormat(str, Enum)` (UP042). `StrEnum` has been in stdlib since Python 3.11 and the project requires 3.12+, so this is a clean drop-in. Instances still equal their string values.
- **Mutable default argument** (B006): `docker_build_cmd` and `build_board` had `extra_args: list[str] = []` — converted to `None` default with `if extra_args is None: extra_args = []` inside.
- **Long f-strings** (E501) in `board_database.py` and `build.py` wrapped across lines.
- **Docker command f-string** in `build.py` had trailing comments that pushed lines over the limit. Hoisted the comments into a block comment above the assignment; removed the now-unnecessary `# fmt: off`/`# fmt: on` directives.
- **Dead expression** `tree.add` in `list_boards.py` (B018) — was a no-op getter access. Removed.

Mass auto-fixes (mostly cosmetic): import sorting (I001), `Optional[X] → X | None` (UP045), `List[X] → list[X]` (UP006), `from typing import Callable → from collections.abc import Callable` (UP035), unused-import cleanup (F401), and `ruff format` formatting.

## Test plan

- [x] `uv run ruff check` — `All checks passed!`.
- [x] `uv run ruff format --check` — `17 files already formatted`.
- [x] `uv run pytest` — 99 passed.
- [x] `uv run pre-commit run --all-files` — all hooks pass.
- [x] Imports still work: `uv run python -c "from mpbuild import OutputFormat; print(OutputFormat.rich == 'rich')"` → `True` (StrEnum equality preserved).

## Follow-up after this lands

The `lint` job, once green on `main`, can be added to required status checks alongside `test`:

```bash
gh api -X PUT repos/mattytrentini/mpbuild/branches/main/protection \
  --input - <<'JSON'
{ ...existing protection...,
  "required_status_checks": { "strict": false, "contexts": ["test", "lint"] }
}
JSON
```

Phase B (adding `ty` as a warn-only typecheck job + pre-commit hook) lands separately.