### PR TITLE
Add ty type checker (warn-only)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,23 @@ jobs:
 
       - name: Ruff format check
         run: uv run ruff format --check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    # ty is in active development; warn-only initially. Drop continue-on-error
+    # once we trust the output and want it gating merges.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dev dependencies
+        run: uv sync --group dev
+
+      - name: ty check
+        run: uv run ty check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,15 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
+
+# ty (Astral type checker) is invoked via the local uv environment because
+# astral-sh/ty-pre-commit does not yet exist. Switch to the upstream hook
+# repo when it ships.
+- repo: local
+  hooks:
+    - id: ty
+      name: ty
+      entry: uv run ty check
+      language: system
+      pass_filenames: false
+      types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pytest>=8",
     "pytest-cov>=5",
     "ruff>=0.13",
+    "ty>=0.0.32",
 ]
 
 [tool.pytest.ini_options]

--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -314,8 +314,9 @@ def build_board(
     #    >>> len(db.boards())
     #    169  # 3x boards are the 'special' boards without deployment instructions.
     if _board.deploy and "clean" not in extra_args and proc.returncode == 0:
-        if _board.deploy_filename.is_file():
-            print(Panel(Markdown(_board.deploy_filename.read_text())))
+        deploy_path = _board.deploy_filename
+        if deploy_path is not None and deploy_path.is_file():
+            print(Panel(Markdown(deploy_path.read_text())))
 
 
 def clean_board(

--- a/src/mpbuild/check_images.py
+++ b/src/mpbuild/check_images.py
@@ -10,7 +10,7 @@ from rich.table import Table
 from . import board_database
 
 
-def check_boards(verbose: bool = False, mpy_dir: str = None) -> None:
+def check_boards(verbose: bool = False, mpy_dir: str | None = None) -> None:
     db = board_database(mpy_dir)
     num_boards = len(db.boards)
 
@@ -109,6 +109,6 @@ def check_boards(verbose: bool = False, mpy_dir: str = None) -> None:
 
 
 # Backwards compatibility
-def check_images(verbose: bool = False, mpy_dir: str = None) -> None:
+def check_images(verbose: bool = False, mpy_dir: str | None = None) -> None:
     """Legacy function, redirects to check_boards"""
     check_boards(verbose, mpy_dir)

--- a/src/mpbuild/cli.py
+++ b/src/mpbuild/cli.py
@@ -24,7 +24,9 @@ def _complete_board(incomplete: str):
 
 
 def _complete_variant(ctx: typer.Context, incomplete: str):
-    board = ctx.params.get("board") or []
+    board = ctx.params.get("board")
+    if not board:
+        return []
     return _complete(list_variants_for_board(board), incomplete)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -188,6 +188,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -202,6 +203,7 @@ dev = [
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-cov", specifier = ">=5" },
     { name = "ruff", specifier = ">=0.13" },
+    { name = "ty", specifier = ">=0.0.32" },
 ]
 
 [[package]]
@@ -366,6 +368,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/7e/2aa791c9ae7b8cd5024cd4122e92267f664ca954cea3def3211919fa3c1f/ty-0.0.32.tar.gz", hash = "sha256:8743174c5f920f6700a4a0c9de140109189192ba16226884cd50095b43b8a45c", size = 5522294, upload-time = "2026-04-20T19:29:01.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/eb/1075dc6a49d7acbe2584ae4d5b410c41b1f177a5adcc567e09eca4c69000/ty-0.0.32-py3-none-linux_armv6l.whl", hash = "sha256:dacbc2f6cd698d488ae7436838ff929570455bf94bfa4d9fe57a630c552aff83", size = 10902959, upload-time = "2026-04-20T19:28:31.907Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d2/c35fc8bc66e98d1ee9b0f8ed319bf743e450e1f1e997574b178fab75670f/ty-0.0.32-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:914bbc4f605ce2a9e2a78982e28fae1d3359a169d141f9dc3b4c7749cd5eca81", size = 10726172, upload-time = "2026-04-20T19:28:44.765Z" },
+    { url = "https://files.pythonhosted.org/packages/96/32/c827da3ca480456fb02d8cea68a2609273b6c220fea0be9a4c8d8470b86e/ty-0.0.32-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4787ac9fe1f86b1f3133f5c6732adbe2df5668b50c679ac6e2d98cd284da812f", size = 10163701, upload-time = "2026-04-20T19:28:27.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9e/2734478fbdb90c160cb2813a3916a16a2af5c1e231f87d635f6131d781fb/ty-0.0.32-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8ea0a728af99fe40dd744cba6441a2404f80b7f4bde17aa6da393810af5ea57", size = 10656220, upload-time = "2026-04-20T19:29:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9f/0007da2d35e424debe7e9f86ffbc1ab7f60983cfbc5f0411324ab2de5292/ty-0.0.32-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2850561f9b018ae33d7e5bbfa0ac414d3c518513edcffe43877dc9801446b9c5", size = 10696086, upload-time = "2026-04-20T19:28:46.829Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5e/ce5fd4ec803222ae3e69a76d2a2db2eed55e19f5b131702b9789ef45f93d/ty-0.0.32-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5fa2fb3c614349ee211d36476b49d88c5ef79a687cdb91b2872ad023b94d2f8", size = 11184800, upload-time = "2026-04-20T19:28:42.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/46/ebcf67a5999421331214aac51a7464db42de2be15bbe929c612a3ed0b039/ty-0.0.32-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2b89969307ab2417d41c9be8059dd79feea577234e1e10d35132f5495e0d42c6", size = 11718718, upload-time = "2026-04-20T19:28:36.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/2141c86ed0ce0962b45cefb658a95e734f59759d47f20afdcd9c732910a1/ty-0.0.32-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b59868ede9b1d69a088f0d695df52a0061f95fa7baa1d5e0dc6fc9cf06e1334", size = 11346369, upload-time = "2026-04-20T19:28:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/da/ed6f772339cf29bd9a46def9d6db5084689eb574ee4d150ff704224c1ed8/ty-0.0.32-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8300caf35345498e9b9b03e550bba03cee8f5f5f8ab4c83c3b1ff1b7403b7d3a", size = 11280714, upload-time = "2026-04-20T19:28:51.516Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9b/c6813987edf4816a40e0c8e408b555f97d3f267c7b3a1688c8bbdf65609c/ty-0.0.32-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:583c7094f4574b02f724db924f98b804d1387a0bd9405ecb5e078cc0f47fbcfb", size = 10638806, upload-time = "2026-04-20T19:28:29.651Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d4/0cefcbd2ad0f3d51762ccf58e652ec7da146eb6ae34f87228f6254bbb8be/ty-0.0.32-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e44ebe1bb4143a5628bc4db67ac0dfebe14594af671e4ee66f6f2e983da56501", size = 10726106, upload-time = "2026-04-20T19:29:06.3Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ad/2c8a97f91f06311f4367400f7d13534bbda2522c73c99a3e4c0757dff9b8/ty-0.0.32-py3-none-musllinux_1_2_i686.whl", hash = "sha256:06f17ada3e069cba6148342ef88e9929156beca8473e8d4f101b68f66c75643e", size = 10872951, upload-time = "2026-04-20T19:28:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/68/42293f9248106dd51875120971a5cc6ea315c2c4dcfb8e59aa063aa0af26/ty-0.0.32-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e96e60fa556cec04f15d7ea62d2ceee5982bd389233e961ab9fd42304e278175", size = 11363334, upload-time = "2026-04-20T19:28:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/df/92/be9abf4d3e589ad5023e2ea965b93e204ec856420d46adf73c5c36c04678/ty-0.0.32-py3-none-win32.whl", hash = "sha256:2ff2ebb4986b24aebcf1444db7db5ca41b36086040e95eea9f8fb851c11e805c", size = 10260689, upload-time = "2026-04-20T19:28:56.541Z" },
+    { url = "https://files.pythonhosted.org/packages/14/61/dc86acea899349d2579cb8419aecedd83dc504d7d6a10df65eef546c8300/ty-0.0.32-py3-none-win_amd64.whl", hash = "sha256:ba7284a4a954b598c1b31500352b3ec1f89bff533825592b5958848226fdc7ee", size = 11255371, upload-time = "2026-04-20T19:28:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/43/01/beffec56d71ca25b343ede63adb076456b5b3e211f1c066452a44cd120b3/ty-0.0.32-py3-none-win_arm64.whl", hash = "sha256:7e10aadbdbda989a7d567ee6a37f8b98d4d542e31e3b190a2879fd581f75d658", size = 10658087, upload-time = "2026-04-20T19:28:59.286Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase B — adds Astral's `ty` type checker to the dev environment, pre-commit config, and CI workflow. CI is **warn-only** initially (`continue-on-error: true`) per the plan; once the suite has settled and we trust the output we'll drop the flag and add `typecheck` to required status checks.

**Tool/config changes**
- `pyproject.toml`: `ty` added to the `dev` group (uv resolved `0.0.32`).
- `.pre-commit-config.yaml`: a `local` hook running `uv run ty check`. There's no `astral-sh/ty-pre-commit` repo yet (verified — `gh api` returns 404); a comment notes the intent to switch to it when it ships.
- `.github/workflows/test.yml`: new parallel `typecheck` job marked `continue-on-error: true`.

**Source fixes (5 ty diagnostics, all real issues)**

| Site | Diagnostic | Fix |
|---|---|---|
| `build.py:317–318` | `Path \| None` accessed without guard — would crash if `Board.deploy_filename` returned None | Bind to a local, check for None |
| `check_images.py:13` and `:112` | `mpy_dir: str = None` (default-value type mismatch — a pre-PEP-604-style annotation bug) | `str \| None = None` |
| `cli.py:_complete_variant` | `ctx.params.get("board") or []` produced a list when no board was set, then passed to `list_variants_for_board(board: str)` — type-incorrect, would raise | Early-return `[]` when no board is set |

The `build.py` fix is the most consequential — the surrounding `if _board.deploy and …` guarantees non-None in practice, but the previous code would have crashed if anyone ever called `build_board` for a board with `deploy = []` and reached that branch.

## Test plan

- [x] `uv run ty check` — `All checks passed!`
- [x] `uv run ruff check && uv run ruff format --check` — green.
- [x] `uv run pytest` — 99 passed.
- [x] `uv run pre-commit run --all-files` — all hooks (incl. new `ty`) pass.

## Follow-ups (out of scope)

- Once we've seen the `typecheck` job run cleanly on a few PRs, drop `continue-on-error: true` and add `typecheck` to required status checks (alongside `test` and `lint`).
- Switch the local pre-commit hook to `astral-sh/ty-pre-commit` if/when that repo materialises.