### PR TITLE
Add rebuild — clean-then-build in CLI and TUI

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -330,3 +330,34 @@ def clean_board(
         mpy_dir=mpy_dir,
         extra_args=["clean"],
     )
+
+
+def rebuild_board(
+    board: str,
+    variant: str | None = None,
+    extra_args: list[str] | None = None,
+    build_container_override: str | None = None,
+    mpy_dir: str | Path | None = None,
+) -> None:
+    """Clean and then build a board.
+
+    Calls ``build_board`` twice (clean phase, then build phase) so the build
+    container override and any extra make args are preserved for both phases.
+    If the clean phase fails ``build_board`` raises ``SystemExit`` and the
+    build phase is skipped — which is the right behaviour because a failed
+    clean leaves the build state unknown.
+    """
+    build_board(
+        board=board,
+        variant=variant,
+        extra_args=["clean"],
+        build_container_override=build_container_override,
+        mpy_dir=mpy_dir,
+    )
+    build_board(
+        board=board,
+        variant=variant,
+        extra_args=extra_args,
+        build_container_override=build_container_override,
+        mpy_dir=mpy_dir,
+    )

--- a/src/mpbuild/cli.py
+++ b/src/mpbuild/cli.py
@@ -3,7 +3,7 @@ from typing import Annotated
 import typer
 
 from . import OutputFormat, __app_name__, __version__
-from .build import build_board, clean_board
+from .build import build_board, clean_board, rebuild_board
 from .check_images import check_boards
 from .completions import list_boards, list_ports, list_variants_for_board
 from .list_boards import print_boards
@@ -55,6 +55,29 @@ def build(
     if variant == "":
         variant = None
     build_board(board, variant, extra_args or [], build_container)
+
+
+@app.command()
+def rebuild(
+    board: Annotated[str, typer.Argument(help="Board name", autocompletion=_complete_board)],
+    variant: Annotated[
+        str | None,
+        typer.Argument(help="Board variant", autocompletion=_complete_variant),
+    ] = None,
+    extra_args: Annotated[
+        list[str] | None, typer.Argument(help="additional arguments to pass to make")
+    ] = None,
+    build_container: Annotated[
+        str | None,
+        typer.Option(help="Override the default build container"),
+    ] = None,
+) -> None:
+    """
+    Clean and then build a MicroPython board.
+    """
+    if variant == "":
+        variant = None
+    rebuild_board(board, variant, extra_args or [], build_container)
 
 
 @app.command()

--- a/src/mpbuild/interactive.py
+++ b/src/mpbuild/interactive.py
@@ -78,6 +78,7 @@ class MpBuildApp(App):
     BINDINGS = [
         ("q", "quit", "Quit"),
         ("b", "build", "Build"),
+        ("r", "rebuild", "Rebuild"),
         ("c", "clean", "Clean"),
         ("s", "stop", "Stop"),
     ]
@@ -92,6 +93,7 @@ class MpBuildApp(App):
                     yield Select([], id="variant-select", prompt="Variant")
                     with Horizontal(id="action-row"):
                         yield Button("Build", id="build-btn", variant="primary")
+                        yield Button("Rebuild", id="rebuild-btn", variant="success")
                         yield Button("Clean", id="clean-btn", variant="warning")
                         yield Button("Stop", id="stop-btn", variant="error")
                 yield RichLog(id="build-log", wrap=False, highlight=True, markup=True)
@@ -126,15 +128,17 @@ class MpBuildApp(App):
                 port_node.add_leaf(board.name, data=board)
 
     def _refresh_action_state(self) -> None:
-        """Recompute Build/Clean/Stop/variant-select enable states.
+        """Recompute Build/Rebuild/Clean/Stop/variant-select enable states.
 
-        - Build/Clean/variant: enabled iff a board is selected (regardless of
-          whether a build is running — Option B lets you replace mid-flight).
+        - Build/Rebuild/Clean/variant: enabled iff a board is selected
+          (regardless of whether a build is running — Option B lets you
+          replace mid-flight).
         - Stop: enabled iff a build is currently running.
         """
         has_board = self._selected_board is not None
         is_running = self._running_proc is not None and self._running_proc.poll() is None
         self.query_one("#build-btn", Button).disabled = not has_board
+        self.query_one("#rebuild-btn", Button).disabled = not has_board
         self.query_one("#clean-btn", Button).disabled = not has_board
         self.query_one("#variant-select", Select).disabled = not has_board
         self.query_one("#stop-btn", Button).disabled = not is_running
@@ -178,55 +182,105 @@ class MpBuildApp(App):
         if not self._selected_board:
             return
         if event.button.id == "build-btn":
-            self._run_build(do_clean=False)
+            self._run_build(do_clean=False, do_build=True)
+        elif event.button.id == "rebuild-btn":
+            self._run_build(do_clean=True, do_build=True)
         elif event.button.id == "clean-btn":
-            self._run_build(do_clean=True)
+            self._run_build(do_clean=True, do_build=False)
 
     def action_build(self) -> None:
         if self._selected_board:
-            self._run_build(do_clean=False)
+            self._run_build(do_clean=False, do_build=True)
+
+    def action_rebuild(self) -> None:
+        if self._selected_board:
+            self._run_build(do_clean=True, do_build=True)
 
     def action_clean(self) -> None:
         if self._selected_board:
-            self._run_build(do_clean=True)
+            self._run_build(do_clean=True, do_build=False)
 
     def action_stop(self) -> None:
         self._terminate_running()
 
-    def _run_build(self, *, do_clean: bool) -> None:
+    def _run_build(self, *, do_clean: bool, do_build: bool) -> None:
         board = self._selected_board
         assert board is not None
-        # Implicit cancellation: clicking Build/Clean while a build runs
-        # terminates the current one before starting the replacement.
+        # Implicit cancellation: clicking Build/Rebuild/Clean while a build
+        # runs terminates the current one before starting the replacement.
         self._terminate_running()
-        log = self.query_one("#build-log", RichLog)
-        log.clear()
-        title = "Cleaning" if do_clean else "Building"
+        self.query_one("#build-log", RichLog).clear()
         variant = self._selected_variant()
-        suffix = f" ({variant})" if variant else ""
-        log.border_title = f"{title} {board.name}{suffix}"
-        log.write(f"[bold cyan][{title} {board.name}{suffix}][/]")
-        self._stream_build(board, variant, do_clean)
+        self._stream_build(board, variant, do_clean=do_clean, do_build=do_build)
 
     @work(thread=True, group="build")
-    def _stream_build(self, board: Board, variant: str | None, do_clean: bool) -> None:
+    def _stream_build(
+        self,
+        board: Board,
+        variant: str | None,
+        *,
+        do_clean: bool,
+        do_build: bool,
+    ) -> None:
+        """Stream up to two docker phases sequentially.
+
+        - Clean only:   do_clean=True, do_build=False
+        - Build only:   do_clean=False, do_build=True
+        - Rebuild:      do_clean=True, do_build=True (clean then build;
+                        the build phase is skipped if clean fails)
+        """
+        suffix = f" ({variant})" if variant else ""
         try:
-            cmd = docker_build_cmd(
-                board=board,
-                variant=variant,
-                do_clean=do_clean,
-                docker_interactive=False,
+            clean_cmd = (
+                docker_build_cmd(
+                    board=board, variant=variant, do_clean=True, docker_interactive=False
+                )
+                if do_clean
+                else None
+            )
+            build_cmd = (
+                docker_build_cmd(
+                    board=board, variant=variant, do_clean=False, docker_interactive=False
+                )
+                if do_build
+                else None
             )
         except Exception as e:  # ValueError from unknown variant, etc.
             self.call_from_thread(self._log_line, f"[red]error:[/] {e}")
             return
+
+        last_proc: subprocess.Popen[str] | None = None
+        if clean_cmd is not None:
+            last_proc = self._run_phase(f"Cleaning {board.name}{suffix}", clean_cmd)
+            if last_proc.returncode != 0 and build_cmd is not None:
+                self.call_from_thread(
+                    self._log_line,
+                    "[red]Build skipped because clean failed.[/]",
+                )
+                self.call_from_thread(self._on_build_finished, last_proc)
+                return
+        if build_cmd is not None:
+            last_proc = self._run_phase(f"Building {board.name}{suffix}", build_cmd)
+        if last_proc is not None:
+            self.call_from_thread(self._on_build_finished, last_proc)
+
+    def _run_phase(self, label: str, cmd: str) -> subprocess.Popen[str]:
+        """Run one docker invocation, stream its output, return the finished Popen.
+
+        Called from inside the @work thread; uses call_from_thread for any UI
+        state changes (log writes, border title, running-proc handle).
+        """
+        self.call_from_thread(self._set_log_phase, label)
         proc = _spawn(cmd)
         self.call_from_thread(self._set_running_proc, proc)
-        try:
-            for line in _stream_proc(proc):
-                self.call_from_thread(self._log_line, line)
-        finally:
-            self.call_from_thread(self._on_build_finished, proc)
+        for line in _stream_proc(proc):
+            self.call_from_thread(self._log_line, line)
+        return proc
+
+    def _set_log_phase(self, label: str) -> None:
+        log = self.query_one("#build-log", RichLog)
+        log.border_title = label
+        log.write(f"[bold cyan][{label}][/]")
 
     def _set_running_proc(self, proc: subprocess.Popen[str]) -> None:
         self._running_proc = proc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,6 +104,49 @@ class TestBuild:
 
 
 # ===================================================================
+# rebuild
+# ===================================================================
+class TestRebuild:
+    def test_dispatches_with_defaults(self, runner, monkeypatch):
+        """`mpbuild rebuild BOARD` calls rebuild_board with default-shaped args."""
+        called = {}
+
+        def fake(board, variant, extra_args, build_container):
+            called.update(
+                board=board,
+                variant=variant,
+                extra_args=extra_args,
+                build_container=build_container,
+            )
+
+        monkeypatch.setattr("mpbuild.cli.rebuild_board", fake)
+
+        result = runner.invoke(app, ["rebuild", "PYBV11"])
+
+        assert result.exit_code == 0
+        assert called == {
+            "board": "PYBV11",
+            "variant": None,
+            "extra_args": [],
+            "build_container": None,
+        }
+
+    def test_with_variant_and_container_override(self, runner, monkeypatch):
+        """Variant positional and --build-container option are forwarded."""
+        called = {}
+        monkeypatch.setattr(
+            "mpbuild.cli.rebuild_board",
+            lambda b, v, e, c: called.update(b=b, v=v, e=e, c=c),
+        )
+        result = runner.invoke(
+            app,
+            ["rebuild", "--build-container", "custom/image:tag", "PYBV11", "DP_THREAD"],
+        )
+        assert result.exit_code == 0
+        assert called == {"b": "PYBV11", "v": "DP_THREAD", "e": [], "c": "custom/image:tag"}
+
+
+# ===================================================================
 # clean
 # ===================================================================
 class TestClean:

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -80,6 +80,7 @@ async def test_actions_disabled_until_board_selected(populated_mpy_root):
     app = MpBuildApp()
     async with app.run_test():
         assert app.query_one("#build-btn", Button).disabled is True
+        assert app.query_one("#rebuild-btn", Button).disabled is True
         assert app.query_one("#clean-btn", Button).disabled is True
         assert app.query_one("#stop-btn", Button).disabled is True
         assert app.query_one("#variant-select", Select).disabled is True
@@ -226,13 +227,18 @@ class FakeProc:
     (or the iterator is exhausted naturally).
     """
 
-    def __init__(self, lines: list[str] | None = None) -> None:
+    def __init__(self, lines: list[str] | None = None, complete_with: int | None = None) -> None:
         import threading
 
         self._lines = list(lines or [])
         self._terminate_event = threading.Event()
         self._terminated = False
         self.returncode: int | None = None
+        if complete_with is not None:
+            # "Already completed" mode: returncode is set, event is fired, so
+            # wait() returns immediately and the iterator exits after lines.
+            self.returncode = complete_with
+            self._terminate_event.set()
         self.stdout = self._iter_lines()
 
     def _iter_lines(self):
@@ -345,3 +351,36 @@ async def test_log_header_names_running_build(populated_mpy_root, monkeypatch):
         assert "Building PYBV11" in rendered
         fake.terminate()
         await pilot.pause(0.1)
+
+
+async def test_rebuild_runs_clean_then_build(populated_mpy_root, monkeypatch):
+    """Pressing `r` spawns two docker invocations in order: clean then build."""
+    cmds_seen: list[str] = []
+
+    def fake_spawn(cmd: str):
+        cmds_seen.append(cmd)
+        # complete_with=0 so the first phase exits cleanly and the worker
+        # proceeds to the second phase without us having to call .terminate().
+        return FakeProc(lines=[], complete_with=0)
+
+    monkeypatch.setattr("mpbuild.interactive._spawn", fake_spawn)
+    app = MpBuildApp()
+    async with app.run_test() as pilot:
+        await _select_pybv11(app, pilot)
+        await pilot.press("r")
+        # Both phases run sequentially in the worker thread; give it time.
+        await pilot.pause(0.3)
+
+        assert len(cmds_seen) == 2, f"expected 2 spawns, got {cmds_seen}"
+        # First phase is clean — docker_build_cmd skips mpy-cross + submodules.
+        assert "make -C mpy-cross" not in cmds_seen[0]
+        assert "BOARD=PYBV11" in cmds_seen[0]
+        # Second phase is build — full make path is present.
+        assert "make -C mpy-cross" in cmds_seen[1]
+        assert "BOARD=PYBV11" in cmds_seen[1]
+
+        # Log should contain both phase headers.
+        log = app.query_one("#build-log", RichLog)
+        rendered = "\n".join(str(line.text) for line in log.lines)
+        assert "Cleaning PYBV11" in rendered
+        assert "Building PYBV11" in rendered


### PR DESCRIPTION
## Summary

New `mpbuild rebuild BOARD [VARIANT]` subcommand and a matching Rebuild button + `r` keybinding in the TUI. Both run a clean phase followed by a build phase, sharing the same variant / extra make args / `--build-container` override.

### CLI

```bash
mpbuild rebuild PYBV11                       # clean then build PYBV11
mpbuild rebuild PYBV11 DP_THREAD             # variant
mpbuild rebuild PYBV11 --build-container ... # container override
```

Implementation is a thin orchestrator in `src/mpbuild/build.py` that calls `build_board()` twice (clean phase, then build phase). Because `build_board` already raises `SystemExit(returncode)` on docker non-zero exit, a failed clean naturally aborts the rebuild without entering the build phase — which is the right behaviour because a failed clean leaves the build state unknown.

### TUI

- New **Rebuild** button (success/green variant), placed between Build and Clean in the action row.
- New `r` keybinding (visible in the footer alongside `b`/`c`/`s`/`q`).
- The existing worker has been generalised from a single `do_clean: bool` to the pair `do_clean` + `do_build`. Three modes:

| Action | do_clean | do_build |
|---|---|---|
| Build | False | True |
| Clean | True | False |
| Rebuild | True | True |

- The worker now runs phases sequentially via a new `_run_phase` helper. For rebuild, the clean phase runs first; its returncode is checked; if non-zero, the worker logs *"Build skipped because clean failed"* and stops. Otherwise the build phase runs.
- Stop, log border-title, and the `_running_proc` swap-between-phases logic mean cancelling mid-rebuild does the obvious thing: pressing Stop during the build phase terminates that phase (the clean phase has already completed).

### Tests

- `tests/test_cli.py` — new `TestRebuild` class: dispatch with defaults, and with variant + `--build-container`.
- `tests/test_interactive.py`:
  - existing `test_actions_disabled_until_board_selected` now also asserts `#rebuild-btn` is disabled at start.
  - new `test_rebuild_runs_clean_then_build` — pressing `r` produces two `_spawn(cmd)` calls in order; the first command lacks `make -C mpy-cross` (clean shape), the second contains it (build shape); the log scrollback shows both `Cleaning PYBV11` and `Building PYBV11` headers. The test uses a new `FakeProc(complete_with=0)` mode so the first fake-process exits cleanly and the worker advances to the second phase without an explicit terminate.

**118 tests total** (up from 115), all green locally with `pytest` / `ruff` / `ty` / `pre-commit`.

## Test plan
- [x] `uv run pytest` — 118 passed.
- [x] `uv run ruff check && uv run ruff format --check` — green.
- [x] `uv run ty check` — green.
- [x] `uv run pre-commit run --all-files` — green.
- [x] Manual smoke from inside a real MicroPython tree:
  - `uv run mpbuild rebuild PYBV11` — verify clean docker container runs, exits, then build docker container runs.
  - `uv run mpbuild --interactive` — select PYBV11, press `r`, watch both phase headers and the log streams; press `s` mid-build to confirm the build phase terminates; relaunch `r` to confirm clean restart.

(Marking the manual smoke unchecked since I can't run docker from this environment.)