### PR TITLE
Release v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Remove build artifacts:
 mpbuild clean BOARD [VARIANT]
 ```
 
+Clean and then build a board (rebuild from scratch):
+
+```bash
+mpbuild rebuild BOARD [VARIANT]
+```
+
 List the available boards, optionally filter by the port name.
 
 Displays the board names (as a clickable link), variants and number of boards per port:
@@ -62,7 +68,7 @@ mpbuild --interactive   # or `mpbuild -i`
 
 ![Interactive TUI screenshot](docs/mpbuild_interactive_screenshot.png)
 
-The left pane shows every port and board found in the MicroPython tree. Selecting a board fills the right pane with its metadata, reveals a variant dropdown if the board has variants, and enables the Build / Clean buttons. The bottom-right log streams docker output as the build runs.
+The left pane shows every port and board found in the MicroPython tree. Selecting a board fills the right pane with its metadata, reveals a variant dropdown if the board has variants, and enables the Build / Rebuild / Clean buttons. The bottom-right log streams docker output as the build runs.
 
 Key bindings:
 
@@ -73,11 +79,12 @@ Key bindings:
 | `←` | Collapse the current branch (or, on a leaf, collapse the parent) |
 | `Enter` | Select |
 | `b` | Build the selected board |
+| `r` | Rebuild the selected board (clean then build) |
 | `c` | Clean the selected board |
 | `s` | Stop the running build |
 | `q` | Quit |
 
-Clicking **Build** while a build is already running terminates the running container before starting the new one. **Stop** is enabled only while a build is actually streaming.
+Clicking **Build**, **Rebuild**, or **Clean** while a build is already running terminates the running container before starting the new one. **Stop** is enabled only while a build is actually streaming.
 
 ## Advanced Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mpbuild"
-version = "0.9.1"
+version = "1.0.0"
 description = "Build MicroPython firmware with ease!"
 authors = [
     { name = "Matt Trentini", email = "matt.trentini@gmail.com" }

--- a/src/mpbuild/__init__.py
+++ b/src/mpbuild/__init__.py
@@ -1,5 +1,5 @@
 __app_name__ = "mpbuild"
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 
 from enum import StrEnum
 from functools import cache

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "mpbuild"
-version = "0.9.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary

Cuts mpbuild **v1.0.0**.

**Version bump (0.9.1 → 1.0.0)**
- `pyproject.toml` — `project.version`
- `src/mpbuild/__init__.py` — `__version__` was `0.1.0` (long stale; this is what `mpbuild --version` actually prints, so the CLI now reports the real version)
- `uv.lock` — regenerated

**README — document `rebuild`**
- Usage: new "Clean and then build" block for `mpbuild rebuild BOARD [VARIANT]`
- Interactive mode: new `r` row in the keybindings table
- Interactive mode prose: updates "Build / Clean" → "Build / Rebuild / Clean" where appropriate

## Why now

PyPI's `mpbuild==0.9.1` (uploaded 2025-10-16) is broken on a fresh install — the `typing_extensions` `ModuleNotFoundError` was fixed shortly after on `main` but never released. Since then `main` has also gained a real test suite, ruff + ty + pre-commit gates, CI on every PR, branch protection with required status checks, a Textual TUI behind `--interactive`, the `rebuild` subcommand, webassembly + windows port support, and git-worktree support. The CLI surface that 0.9.1 documented is stable; tagging 1.0.0 both unbreaks fresh installs and flags the maturity of the CLI.

## Test plan
- [x] `uv run ruff check && uv run ruff format --check` — green.
- [x] `uv run ty check` — green.
- [x] `uv run pytest` — 123 passed.
- [x] `uv run pre-commit run --all-files` — green.
- [x] `uv run mpbuild --version` → `mpbuild v1.0.0`.

## Follow-ups (after merge)
1. Tag `v1.0.0` on `main` and push.
2. `uv build && uv publish`.
3. `gh release create v1.0.0 --generate-notes --title v1.0.0`.