### PR TITLE
Add release workflow (tag-driven PyPI publish + GitHub release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# A tag push triggers a single release; cancelling on a duplicate tag push
+# would be unusual, so no concurrency group needed.
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Upload distribution artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    # The `pypi` environment matches the trusted-publisher config on PyPI.
+    # Pair this with an environment protection rule (Settings -> Environments
+    # -> pypi -> Required reviewers) for a manual approval gate.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/mpbuild/
+    permissions:
+      # Required for PyPI trusted publishing via OIDC. No PyPI token needed.
+      id-token: write
+    steps:
+      - name: Download distribution artefacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so --generate-notes can resolve the previous tag.
+          fetch-depth: 0
+
+      - name: Download distribution artefacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --generate-notes \
+            --title "${GITHUB_REF_NAME}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,6 @@ Cutting a release is two steps: merge a version-bump PR, then push a tag. Everyt
 ```bash
 # 1. Open + merge a "Release vX.Y.Z" PR that bumps:
 #    - pyproject.toml (project.version)
-#    - src/mpbuild/__init__.py (__version__)
 #    - uv.lock (uv lock)
 #
 # 2. Tag the merged commit on main and push:
@@ -41,11 +40,12 @@ The CLI is the stable surface that SemVer applies to. The Python module API (`im
 
 ### 2. Open a release PR
 
-Bump these three files in a single PR titled "Release vX.Y.Z":
+Bump these two files in a single PR titled "Release vX.Y.Z":
 
 - `pyproject.toml` — `project.version = "X.Y.Z"`
-- `src/mpbuild/__init__.py` — `__version__ = "X.Y.Z"` (this is what `mpbuild --version` actually prints)
 - `uv.lock` — run `uv lock` after the bump to keep it in sync
+
+`pyproject.toml` is the single source of truth for the version string; `src/mpbuild/__init__.py` reads it at runtime via `importlib.metadata.version("mpbuild")`, so `mpbuild --version` stays in sync automatically.
 
 If anything user-visible changed since the last release (new commands, key bindings, behaviour, etc.), update `README.md` in the same PR.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,128 @@
+# Releasing mpbuild
+
+Cutting a release is two steps: merge a version-bump PR, then push a tag. Everything else (build, PyPI upload, GitHub release) happens automatically via `.github/workflows/release.yml`.
+
+## TL;DR
+
+```bash
+# 1. Open + merge a "Release vX.Y.Z" PR that bumps:
+#    - pyproject.toml (project.version)
+#    - src/mpbuild/__init__.py (__version__)
+#    - uv.lock (uv lock)
+#
+# 2. Tag the merged commit on main and push:
+git checkout main
+git pull --ff-only
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+The tag push triggers the release workflow. Done.
+
+## What a release produces
+
+| Artefact | Where |
+|---|---|
+| New version | https://pypi.org/project/mpbuild/ |
+| Git tag `vX.Y.Z` | https://github.com/mattytrentini/mpbuild/tags |
+| GitHub release with auto-generated notes + wheel/sdist | https://github.com/mattytrentini/mpbuild/releases |
+
+## Step-by-step
+
+### 1. Decide the version
+
+[SemVer](https://semver.org/):
+
+- **Patch** (`1.0.X`) — bug fixes only.
+- **Minor** (`1.X.0`) — backwards-compatible new behaviour.
+- **Major** (`X.0.0`) — breaking change to the CLI.
+
+The CLI is the stable surface that SemVer applies to. The Python module API (`import mpbuild`) is documented as a work in progress; treat changes there as out of band.
+
+### 2. Open a release PR
+
+Bump these three files in a single PR titled "Release vX.Y.Z":
+
+- `pyproject.toml` — `project.version = "X.Y.Z"`
+- `src/mpbuild/__init__.py` — `__version__ = "X.Y.Z"` (this is what `mpbuild --version` actually prints)
+- `uv.lock` — run `uv lock` after the bump to keep it in sync
+
+If anything user-visible changed since the last release (new commands, key bindings, behaviour, etc.), update `README.md` in the same PR.
+
+Branch protection requires CI to pass: `test`, `lint`, and `typecheck` all run automatically. The PR's CI must be green before merge.
+
+### 3. Tag the merged commit and push
+
+```bash
+git checkout main
+git pull --ff-only        # picks up the merged release PR
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Annotated tags (`-a -m`) record the tagger and a tag message, which downstream tooling (e.g. release notes, `git describe`) prefers over lightweight tags.
+
+### 4. Watch the workflow
+
+```bash
+gh run watch
+# or browse https://github.com/mattytrentini/mpbuild/actions
+```
+
+Three sequential jobs:
+
+1. **`build`** — `uv build` creates the wheel + sdist and uploads them as a workflow artefact.
+2. **`publish-pypi`** — uploads to PyPI via OIDC trusted publishing.
+3. **`github-release`** — creates the GitHub release with `--generate-notes`, attaching the wheel + sdist as assets.
+
+If the `pypi` GitHub Environment has "Required reviewers" enabled, `publish-pypi` waits for an approval click — that's the chance to download the artefact from the `build` job and sanity-check it before it hits PyPI.
+
+### 5. Verify
+
+After the workflow goes green (~1 minute for PyPI to index, in addition to the workflow time):
+
+```bash
+uv tool install --python 3.12 --force mpbuild==X.Y.Z
+mpbuild --version            # expect: mpbuild vX.Y.Z
+```
+
+Then eyeball the GitHub release page at `https://github.com/mattytrentini/mpbuild/releases/tag/vX.Y.Z` — auto-generated notes can be edited via the UI if you want a "Highlights" section above the PR list.
+
+## One-off setup (already done; here for reference)
+
+PyPI trusted publishing must be configured at https://pypi.org/manage/project/mpbuild/settings/publishing/ with:
+
+- **Owner**: `mattytrentini`
+- **Repository name**: `mpbuild`
+- **Workflow name**: `release.yml`
+- **Environment name**: `pypi`
+
+This is what makes "publish without a long-lived PyPI token" work: PyPI trusts the GitHub Actions OIDC identity for that exact workflow file in that exact repo's `pypi` environment. If any of those four fields don't match between PyPI and the workflow, the upload step fails with an OIDC token error.
+
+## Troubleshooting
+
+**`publish-pypi` fails with "OIDC token" / "trusted publishing" error.**
+The PyPI trusted-publisher record doesn't match the workflow. Re-check the four fields under "One-off setup" above — the workflow filename and environment name are the usual culprits.
+
+**`publish-pypi` fails with "filename already exists" / "version already exists".**
+PyPI doesn't allow overwriting a version. Bump to the next patch (e.g., if `1.0.1` already exists, release `1.0.2`). You can *yank* a broken release on PyPI (`pip` won't install yanked versions unless explicitly pinned) but you can't re-upload the same version number.
+
+**Tag points at the wrong commit.**
+If the workflow hasn't run yet (or hasn't reached `publish-pypi`):
+
+```bash
+git tag -d vX.Y.Z
+git push origin :refs/tags/vX.Y.Z
+# Then re-tag from the correct SHA and push.
+```
+
+If `publish-pypi` already succeeded, the PyPI upload is final — see "yank" above and bump to the next patch.
+
+**You need to undo a release after it shipped.**
+- *PyPI*: yank the version (Manage → Releases → Options → Yank). Don't delete — that breaks reproducibility of anyone who pinned it.
+- *GitHub release*: delete or convert to a pre-release via the UI.
+- *Git tag*: leave it in place. Tags should be immutable once published; deleting them confuses anyone who fetched the repo while the tag existed.
+
+## Why tag-driven?
+
+The tag is the source of truth for what got released. Alternatives (e.g. triggering on PR merge, on a release-please bot) couple "I want to merge a PR" with "I want to publish" — which doesn't always line up. Pushing the tag is an explicit "release this now" gesture and lets the release PR sit on main for a while if you want to bundle several merges into one release.

--- a/src/mpbuild/__init__.py
+++ b/src/mpbuild/__init__.py
@@ -1,12 +1,19 @@
-__app_name__ = "mpbuild"
-__version__ = "1.0.0"
-
 from enum import StrEnum
 from functools import cache
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from .board_database import Database
 from .find_boards import find_mpy_root
+
+__app_name__ = "mpbuild"
+
+try:
+    __version__ = version(__app_name__)
+except PackageNotFoundError:
+    # Running from a source checkout without an installation (e.g. uv tool ran
+    # directly against the repo). Fall back to a sentinel rather than crashing.
+    __version__ = "0.0.0+local"
 
 
 @cache


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` so future releases are kicked off by pushing a `v*` tag — no PyPI tokens stored anywhere, no manual `uv build && uv publish` step.

**Flow after this lands:**

1. Open a tiny "Release vX.Y.Z" PR (`pyproject.toml` + `src/mpbuild/__init__.py` version bump + regenerated `uv.lock`). Merge it.
2. ``git pull --ff-only && git tag vX.Y.Z && git push origin vX.Y.Z``
3. Done — the workflow builds, publishes to PyPI, and creates the GitHub release with auto-generated notes.

## Three sequential jobs

| Job | What it does |
|---|---|
| `build` | `uv build` produces wheel + sdist, uploads as a workflow artefact so the publish + release jobs operate on identical bytes. |
| `publish-pypi` | Uploads via `pypa/gh-action-pypi-publish` using **PyPI Trusted Publishing** (OIDC). No long-lived PyPI token needed. Runs in the `pypi` GitHub Environment so a protection rule can optionally gate the upload on a manual approval click. |
| `github-release` | `gh release create vX.Y.Z dist/* --generate-notes` posts the release with the dist artefacts attached and notes auto-built from PRs since the previous tag. |

## One-off configuration needed on PyPI (out of band)

On `https://pypi.org/manage/project/mpbuild/settings/publishing/` add a trusted publisher with:
- Owner: `mattytrentini`
- Repository: `mpbuild`
- Workflow filename: `release.yml`
- Environment name: `pypi`

Without that record on PyPI, the `publish-pypi` job will fail at the upload step. (User is setting this up in parallel with this PR.)

## Optional manual-approval gate

Under repo Settings → Environments → `pypi` you can add Required Reviewers. With that enabled, the `publish-pypi` job will wait for a click before uploading — useful for double-checking the dist artefacts in the Actions UI before they hit PyPI.

## Test plan

- [x] `uv run pre-commit run --all-files` — clean (includes `check-yaml` on the new file).
- [ ] First end-to-end test: a future `v1.0.1` tag push. (We won't trigger this PR's workflow on merge — it's tag-driven, not push-to-main.)

This PR doesn't change the test/lint/typecheck workflows or the publish-once-from-laptop process that worked for 1.0.0; it just makes future releases push-button.