### PR TITLE
Add baochip port support

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -82,6 +82,7 @@ BUILD_CONTAINERS = {
     "unix": "gcc:12-bookworm",  # Special, doesn't have boards
     "webassembly": ARM_BUILD_CONTAINER,  # installs emsdk on first build
     "windows": WIN_BUILD_CONTAINER,  # cross compile linux to windows
+    "baochip": "micropython/build-micropython-baochip",  # xPack RISC-V + pure25519
 }
 
 

--- a/tests/test_build_container.py
+++ b/tests/test_build_container.py
@@ -40,6 +40,7 @@ class TestSimplePorts:
             ("samd", ARM_BUILD_CONTAINER),
             ("psoc6", "ifxmakers/mpy-mtb-ci"),
             ("esp8266", "larsks/esp-open-sdk"),
+            ("baochip", "micropython/build-micropython-baochip"),
         ],
     )
     def test_physical_port_maps_to_container(self, mpy_root, make_board, port_name, expected):


### PR DESCRIPTION
## Summary

Adds support for the new MicroPython **baochip** port (micropython/micropython#19392 by Andrew Leech) — a VexRiscv RISC-V SoC, first board **DABAO**.

The mpbuild Database walker discovers DABAO from \`board.json\` automatically once the port lands upstream; the only missing piece on the mpbuild side is the \`BUILD_CONTAINERS\` mapping. This PR is **+2 lines**: one map entry + one test row.

> **Draft until upstream lands.** Micropython#19392 is still open against \`micropython:master\`. Without it merged, a regular MicroPython clone has no \`ports/baochip/\` so \`mpbuild build DABAO\` would fail at the make step. Marking ready-for-review once #19392 merges.

## How it works

A new Docker image, \`micropython/build-micropython-baochip\`, has been published to Docker Hub. It's built from a standalone repository following the same pattern as the rp2350riscv image:

- **Container source**: https://github.com/mattytrentini/build-micropython-baochip-docker
- **Image**: \`docker pull micropython/build-micropython-baochip:latest\`

The image bundles [xPack's \`riscv-none-elf-gcc\`](https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack) **15.2.0** (which the baochip Makefile autodetects via its second-choice prefix) and the [\`pure25519\`](https://pypi.org/project/pure25519/) Python package required by the [dabao-sdk](https://github.com/ArmstrongSubero/dabao-sdk)'s UF2-signing step. Newlib comes with the xPack toolchain so libc headers are available out of the box.

Result: the docker command mpbuild emits for DABAO is exactly the standard MicroPython build chain, no per-port quirks:

\`\`\`
docker run --rm ... --user 1000:1000 ... micropython/build-micropython-baochip \\
  bash -c "git config --global --add safe.directory '*' 2>/dev/null; \\
           make -C mpy-cross && \\
           make -C ports/baochip BOARD=DABAO submodules && \\
           make -j N -C ports/baochip BOARD=DABAO"
\`\`\`

No \`CROSS_COMPILE=\` override, no per-build \`pip install\`, no \`ci_baochip_setup\` invocation. Just docker run.

## Why a dedicated image

Debian's packaged \`gcc-riscv64-unknown-elf\` is a compiler-only package — no bundled libc and the picolibc-via-specs path doesn't propagate through MicroPython's qstr preprocessing step. The xPack distribution sidesteps this by shipping a fully-integrated toolchain (compiler + newlib) as a single tarball. Reusing the rp2350riscv image was the initial attempt (an earlier iteration of this branch); it worked but required three workarounds (CROSS_COMPILE override on both make calls plus an in-container pip install of pure25519) that all vanish with a purpose-built image.

## Verification

End-to-end against a local checkout of micropython#19392:

\`\`\`
cd ~/code/micropython/upstream
uv run --project ~/code/mpbuild mpbuild build DABAO
\`\`\`

Produces:
- \`firmware.uf2\` — 423 KB (signed with the SDK's developer Ed25519ph key)
- \`firmware.bin\`, \`firmware.elf\`, \`firmware.map\`
- The DABAO deploy panel rendered

## Test plan
- [x] \`uv run pytest\` — 124 passed (new parametrize row for baochip in \`test_build_container.py\`).
- [x] \`uv run ruff check && uv run ruff format --check\` — green.
- [x] \`uv run ty check\` — green.
- [x] \`uv run pre-commit run --all-files\` — green.
- [x] End-to-end smoke: \`mpbuild build DABAO\` against #19392 produces firmware.uf2.
- [ ] Re-run smoke once upstream #19392 lands on master (sanity check that nothing drifts during their review).