### PR TITLE
Release v1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mpbuild"
-version = "1.0.0"
+version = "1.1.0"
 description = "Build MicroPython firmware with ease!"
 authors = [
     { name = "Matt Trentini", email = "matt.trentini@gmail.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "mpbuild"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary

Cuts mpbuild **v1.1.0**.

**Version bump (1.0.0 → 1.1.0)**
- \`pyproject.toml\` — \`project.version\`
- \`uv.lock\` — regenerated

\`src/mpbuild/__init__.py\` needs no change since v1.0.0 — \`__version__\` is now read from package metadata via \`importlib.metadata\`, so \`mpbuild --version\` will print \`v1.1.0\` automatically.

## Highlights since v1.0.0

- **baochip port support** (#108) — Baochip-1x VexRiscv RISC-V SoC, first board DABAO. Builds via the new dedicated [\`micropython/build-micropython-baochip\`](https://hub.docker.com/r/micropython/build-micropython-baochip) container ([source](https://github.com/mattytrentini/build-micropython-baochip-docker)).
- **Tag-driven release workflow** (#107) — pushing a \`v*\` tag now builds, publishes to PyPI via OIDC trusted publishing, and creates the GitHub release automatically. This is the first release that will actually exercise that flow end-to-end.
- **Version-metadata-read deduplication** — \`pyproject.toml\` is now the single source of truth; \`__version__\` reads from installed package metadata.
- **RELEASE.md** documenting the release process for future maintainers.

GitHub's auto-generated release notes will produce the full list of PRs when the tag is pushed.

## Test plan
- [x] \`uv run pytest\` — 124 passed.
- [x] \`uv run ruff check && uv run ruff format --check\` — green.
- [x] \`uv run ty check\` — green.
- [x] \`uv run mpbuild --version\` → \`mpbuild v1.1.0\`.

## After merge

\`\`\`bash
git checkout main && git pull --ff-only
git tag -a v1.1.0 -m "v1.1.0"
git push origin v1.1.0
\`\`\`

The tag push triggers \`release.yml\`: build → publish to PyPI → GitHub release. If the \`pypi\` GitHub Environment has required reviewers set, the publish job will pause for an approval click before uploading.