### PR TITLE
Add psoc-edge port support

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -77,6 +77,7 @@ BUILD_CONTAINERS = {
     "renesas-ra": ARM_BUILD_CONTAINER,
     "samd": ARM_BUILD_CONTAINER,
     "psoc6": "ifxmakers/mpy-mtb-ci",
+    "psoc-edge": "micropython/build-micropython-psoc-edge",  # arm-none-eabi + edgeprotecttools
     "esp32": f"{ESP_IDF_CONTAINER}:{ESP_IDF_FALLBACK_VERSION}",
     "esp8266": "larsks/esp-open-sdk",
     "unix": "gcc:12-bookworm",  # Special, doesn't have boards

--- a/tests/test_build_container.py
+++ b/tests/test_build_container.py
@@ -39,6 +39,7 @@ class TestSimplePorts:
             ("renesas-ra", ARM_BUILD_CONTAINER),
             ("samd", ARM_BUILD_CONTAINER),
             ("psoc6", "ifxmakers/mpy-mtb-ci"),
+            ("psoc-edge", "micropython/build-micropython-psoc-edge"),
             ("esp8266", "larsks/esp-open-sdk"),
             ("baochip", "micropython/build-micropython-baochip"),
         ],


### PR DESCRIPTION
## Summary

Adds support for the new **psoc-edge** MicroPython port introduced in [micropython/micropython#18910](https://github.com/micropython/micropython/pull/18910) — Infineon's PSOC Edge family, first board `KIT_PSE84_AI` (PSE846GPS2DBZC4 MCU). This is a different chip line to the existing `psoc6` port; both entries coexist in `BUILD_CONTAINERS`.

Two-line change:

- `src/mpbuild/build.py` — new `BUILD_CONTAINERS` entry mapping `psoc-edge` -> `micropython/build-micropython-psoc-edge`.
- `tests/test_build_container.py` — one row in `TestSimplePorts.test_physical_port_maps_to_container`.

## Container

The Dockerfile lives at [`mattytrentini/build-micropython-psoc-edge-docker`](https://github.com/mattytrentini/build-micropython-psoc-edge-docker) and mirrors the pattern used for `baochip` and `rp2350riscv` (dedicated repo, manual push to Docker Hub under `micropython/`). It provides:

- `gcc-arm-none-eabi` + `libnewlib-arm-none-eabi` (matching upstream `ci_gcc_arm_setup`)
- `edgeprotecttools` from PyPI (used by the port's Makefile to sign the hex, do the hex-relocate, and merge secure/non-secure images)
- `zip` (used by the Makefile to bundle `firmware.zip`)

## Test plan

- [x] `pytest tests/test_build_container.py` — 19 passed
- [x] Full suite — 125 passed
- [x] End-to-end: `mpbuild build KIT_PSE84_AI` against the PR head produces `ports/psoc-edge/build-KIT_PSE84_AI/firmware.zip` (~500 KB signed package) and renders the deploy panel

## Blocked on

- Upstream [micropython/micropython#18910](https://github.com/micropython/micropython/pull/18910) merging — this PR should stay draft until then (same as baochip #108 was).