### PR TITLE
Release v1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mpbuild"
-version = "1.1.0"
+version = "1.2.0"
 description = "Build MicroPython firmware with ease!"
 authors = [
     { name = "Matt Trentini", email = "matt.trentini@gmail.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "mpbuild"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` (and `uv.lock`) to `1.2.0` to cut the next release.

## What's new since v1.1.0

- **psoc-edge port support** — Registers Infineon's new PSOC Edge port (upstream [micropython/micropython#18910](https://github.com/micropython/micropython/pull/18910), first board `KIT_PSE84_AI`) against a dedicated build container. See #110.

Minor version bump per [SemVer](https://semver.org/) — new backwards-compatible functionality, no CLI changes.

## Test plan

- [x] CI green (test / lint / typecheck)
- [ ] Merge, then tag `v1.2.0` on the merged main tip to fire the release workflow (per `RELEASE.md`)