### PR TITLE
Add alif port support

### DIFF
--- a/src/mpbuild/build.py
+++ b/src/mpbuild/build.py
@@ -76,6 +76,7 @@ BUILD_CONTAINERS = {
     "mimxrt": ARM_BUILD_CONTAINER,
     "renesas-ra": ARM_BUILD_CONTAINER,
     "samd": ARM_BUILD_CONTAINER,
+    "alif": ARM_BUILD_CONTAINER,
     "psoc6": "ifxmakers/mpy-mtb-ci",
     "psoc-edge": "micropython/build-micropython-psoc-edge",  # arm-none-eabi + edgeprotecttools
     "esp32": f"{ESP_IDF_CONTAINER}:{ESP_IDF_FALLBACK_VERSION}",

--- a/tests/test_build_container.py
+++ b/tests/test_build_container.py
@@ -38,6 +38,7 @@ class TestSimplePorts:
             ("mimxrt", ARM_BUILD_CONTAINER),
             ("renesas-ra", ARM_BUILD_CONTAINER),
             ("samd", ARM_BUILD_CONTAINER),
+            ("alif", ARM_BUILD_CONTAINER),
             ("psoc6", "ifxmakers/mpy-mtb-ci"),
             ("psoc-edge", "micropython/build-micropython-psoc-edge"),
             ("esp8266", "larsks/esp-open-sdk"),


### PR DESCRIPTION
## Summary
- Registers the new `alif` port (Alif Semiconductor Ensemble E7 M55 boards) against the existing ARM build container.
- `tools/ci.sh`'s `ci_alif_setup` only calls `ci_gcc_arm_setup` — the same `gcc-arm-none-eabi` + `libnewlib-arm-none-eabi` toolchain already used by stm32/rp2/nrf/mimxrt/renesas-ra/samd/sf32 — so no dedicated container is needed here, unlike psoc-edge (`edgeprotecttools`) or baochip (custom RISC-V toolchain).

## Test plan
- [x] Added a parametrized test case (`("alif", ARM_BUILD_CONTAINER)`) in `test_build_container.py`
- [x] Full suite passes: `uv run pytest -q` → 126 passed